### PR TITLE
fix: make ldap connections persistent and restartable

### DIFF
--- a/edumfa/lib/resolver.py
+++ b/edumfa/lib/resolver.py
@@ -41,7 +41,7 @@ import logging
 from .log import log_with
 from .config import (get_resolver_types, get_resolver_classes, get_config_object)
 from edumfa.lib.usercache import delete_user_cache
-from edumfa.lib.framework import get_request_local_store
+from edumfa.lib.framework import get_app_local_store
 from ..models import (Resolver,
                       ResolverConfig)
 from ..api.lib.utils import required
@@ -220,7 +220,7 @@ def delete_resolver(resolvername):
         reso.delete()
         ret = reso.id
     # Delete resolver object from cache
-    store = get_request_local_store()
+    store = get_app_local_store()
     if 'resolver_objects' in store:
         if resolvername in store['resolver_objects']:
             del store['resolver_objects'][resolvername]
@@ -321,7 +321,7 @@ def get_resolver_object(resolvername):
         log.error("Can not find resolver with name {0!s} ".format(resolvername))
         return None
     else:
-        store = get_request_local_store()
+        store = get_app_local_store()
         if 'resolver_objects' not in store:
             store['resolver_objects'] = {}
         resolver_objects = store['resolver_objects']

--- a/edumfa/lib/resolvers/LDAPIdResolver.py
+++ b/edumfa/lib/resolvers/LDAPIdResolver.py
@@ -1270,7 +1270,7 @@ class IdResolver (UserIdResolver):
     @staticmethod
     def create_connection(authtype=None, server=None, user=None,
                           password=None, auto_bind=ldap3.AUTO_BIND_NONE,
-                          client_strategy=ldap3.SYNC,
+                          client_strategy=ldap3.RESTARTABLE,
                           check_names=True,
                           auto_referrals=False,
                           receive_timeout=5,

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ importlib-metadata==6.1.0; python_version > '3.6'
 importlib-resources==5.4.0; python_version == '3.6'
 itsdangerous==1.1.0
 Jinja2==2.11.3
-ldap3==2.8.1
+ldap3==2.9.1
 lxml==4.9.2
 Mako==1.1.6; python_version == '3.6'
 Mako==1.2.4; python_version > '3.6'


### PR DESCRIPTION
previously the request_local_store was used, so new ldap connections were opened per request.
this was changed to a single persistent connection by using app_local_store. which then needs to be restartable.
there is a bug in python-ldap 2.8.1 which causes restartable connections to fail, so we bump to 2.9.1