### PR TITLE
fix: wrong indentation caused false "Action .. requires serial number" line

### DIFF
--- a/edumfa/lib/eventhandler/tokenhandler.py
+++ b/edumfa/lib/eventhandler/tokenhandler.py
@@ -553,9 +553,9 @@ class TokenEventHandler(BaseEventHandler):
                                         " Token serial: {!0s}".format(serial))
 
 
-                else:
-                    log.info("Action {0!s} requires serial number. But no serial "
-                             "number could be found in request {1!s}.".format(action, request))
+            else:
+                log.info("Action {0!s} requires serial number. But no serial "
+                         "number could be found in request {1!s}.".format(action, request))
 
         if action.lower() == ACTION_TYPE.INIT:
             log.info("Initializing new token")


### PR DESCRIPTION
else was aligned wrong and produced log line "Action .. requires serial number" on every action _with_ serial number