### PR TITLE
feat: smstoken: add configurable URL which is called after check, extend test

### DIFF
--- a/edumfa/lib/smsprovider/SMSProvider.py
+++ b/edumfa/lib/smsprovider/SMSProvider.py
@@ -99,6 +99,16 @@ class ISMSProvider(object):
         """
         return True
 
+    def submit_post_check(self, phone, message):  # pragma: no cover
+        """
+        Executes a post check action. It should return a bool indicating
+        if it was executed successfully.
+
+        :return: Success
+        :rtype: bool
+        """
+        return True
+
     def check_configuration(self):
         """
         This method checks the sanity of the configuration of this provider.

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -227,7 +227,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
                                         'SipgateSMSProvider.SipgateSMSProvider')
             smpp_parameters = value.get('edumfa.lib.smsprovider.'
                                         'SmppSMSProvider.SmppSMSProvider')
-            msg2uid_parameters = value.get('privacyidea.lib.smsprovider.'
+            msg2uid_parameters = value.get('edumfa.lib.smsprovider.'
                                          'HttpMessageToUidProvider.HttpMessageToUidProvider')
             self.assertEqual(http_parameters.get("options_allowed"), True)
             self.assertEqual(smtp_parameters.get("options_allowed"), False)

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -217,6 +217,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
                             '.SmppSMSProvider' in value)
             self.assertIn('edumfa.lib.smsprovider.ScriptSMSProvider'
                           '.ScriptSMSProvider', value)
+            self.assertIn('edumfa.lib.smsprovider.HttpMessageToUidProvider'
+                          '.HttpMessageToUidProvider', value)
             http_parameters = value.get('edumfa.lib.smsprovider.'
                                         'HttpSMSProvider.HttpSMSProvider')
             smtp_parameters = value.get('edumfa.lib.smsprovider.'
@@ -225,6 +227,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
                                         'SipgateSMSProvider.SipgateSMSProvider')
             smpp_parameters = value.get('edumfa.lib.smsprovider.'
                                         'SmppSMSProvider.SmppSMSProvider')
+            msg2uid_parameters = value.get('privacyidea.lib.smsprovider.'
+                                         'HttpMessageToUidProvider.HttpMessageToUidProvider')
             self.assertEqual(http_parameters.get("options_allowed"), True)
             self.assertEqual(smtp_parameters.get("options_allowed"), False)
             self.assertEqual(sipgate_parameters.get("options_allowed"), False)
@@ -232,6 +236,9 @@ class APISmsGatewayTestCase(MyApiTestCase):
             self.assertTrue("URL" in http_parameters.get("parameters"))
             self.assertTrue("PROXY" in http_parameters.get("parameters"))
             self.assertTrue("HTTP_METHOD" in http_parameters.get("parameters"))
+            self.assertTrue("URL" in msg2uid_parameters.get("parameters"))
+            self.assertTrue("UID_TOKENINFO_ATTRIBUTE" in msg2uid_parameters.get("parameters"))
+            self.assertTrue("POST_CHECK_URL" in msg2uid_parameters.get("parameters"))
 
     def test_05_read_write_policies(self):
         set_policy(name="pol_read", scope=SCOPE.ADMIN,


### PR DESCRIPTION
Introduce new parameter POST_CHECK_URL which, when set in the SMS gateway definition, is called after validate/check on the token.
This can be used to configure a web hook which clears a TAN message from a device after it was entered.