### PR TITLE
new API endpoint POST /info/<serial> to bulk modify tokeninfo

### DIFF
--- a/edumfa/api/token.py
+++ b/edumfa/api/token.py
@@ -83,6 +83,7 @@ from edumfa.api.lib.postpolicy import (save_pin_change, check_verify_enrollment,
 from edumfa.lib.event import event
 from edumfa.api.auth import admin_required
 from edumfa.lib.subscriptions import CheckSubscription
+import json
 
 token_blueprint = Blueprint('token_blueprint', __name__)
 log = logging.getLogger(__name__)

--- a/edumfa/api/token.py
+++ b/edumfa/api/token.py
@@ -1234,6 +1234,7 @@ def modify_tokeninfo_api(serial):
                 count += add_tokeninfo(serial, key, value)
     success = count > 0
     g.audit_object.log({"success": success})
+    return send_result(success)
 
 
 @token_blueprint.route('/group/<serial>/<groupname>', methods=['POST'])


### PR DESCRIPTION
Create a new API endpoint POST /info/<serial> which modifies the tokeninfo entries for a token with the ghiven serial.
Request body must contain a json dictionary 'info' with key value pairs to set.
Already existing entries with the same key are overwritten, supplied keys with null value are deleted.