### PR TITLE
feat: new comperator to test if given user- or tokeninfo is set & trigger delete modal in UI

### DIFF
--- a/edumfa/api/lib/postpolicy.py
+++ b/edumfa/api/lib/postpolicy.py
@@ -548,6 +548,8 @@ def get_webui_settings(request, response):
                                              user=loginname, realm=realm).any())
         token_rollover = Match.generic(g, scope=SCOPE.WEBUI, action=ACTION.TOKENROLLOVER,
                                        user=loginname, realm=realm).action_values(unique=False)
+        token_ask_delete = Match.generic(g, scope=SCOPE.WEBUI, action=ACTION.TOKEN_ASK_DELETE,
+                                       user=loginname, realm=realm).action_values(unique=False)
         token_wizard = False
         dialog_no_token = False
         if role == ROLE.USER:
@@ -659,6 +661,7 @@ def get_webui_settings(request, response):
         content["result"]["value"]["qr_image_custom"] = qr_image_custom
         content["result"]["value"]["logout_redirect_url"] = logout_redirect_url
         content["result"]["value"]["require_description"] = require_description
+        content["result"]["value"]["token_ask_delete"] = token_ask_delete
         response.set_data(json.dumps(content))
     return response
 

--- a/edumfa/api/policy.py
+++ b/edumfa/api/policy.py
@@ -45,7 +45,8 @@ from ..lib.policy import (set_policy, ACTION,
                           export_policies, import_policies,
                           delete_policy, get_static_policy_definitions,
                           enable_policy, get_policy_condition_sections,
-                          get_policy_condition_comparators, Match)
+                          get_policy_condition_comparators, Match,
+                          get_policy_condition_unset_options)
 from ..lib.token import get_dynamic_policy_definitions
 from ..lib.error import (ParameterError)
 from edumfa.lib.utils import to_unicode, is_true
@@ -126,8 +127,8 @@ def set_policy_api(name=None):
     :jsonparam check_all_resolvers: bool, whether all all resolvers in which
         the user exists should be checked with this policy.
     :jsonparam conditions: a (possibly empty) list of conditions of the policy.
-        Each condition is encoded as a list with 5 elements:
-        ``[section (string), key (string), comparator (string), value (string), active (boolean)]``
+        Each condition is encoded as a list with 6 elements:
+        ``[section (string), key (string), comparator (string), value (string), active (boolean), unset operation (string)]``
         Hence, the ``conditions`` parameter expects a list of lists.
         When eduMFA checks if a defined policy should take effect,
         *all* conditions of the policy must be fulfilled for the policy to match.
@@ -153,7 +154,7 @@ def set_policy_api(name=None):
        action=enroll, disable
 
     The policy POST request can also take the parameter of conditions. This is a list of conditions sets:
-    [ [ "userinfo", "memberOf", "equals", "groupA", "true" ], [ ... ] ]
+    [ [ "userinfo", "memberOf", "equals", "groupA", "true", "exception" ], [ ... ] ]
     With the entries being the ``section``, the ``key``, the ``comparator``, the ``value`` and ``active``.
     For more on conditions see :ref:`policy_conditions`.
 
@@ -529,6 +530,9 @@ def get_policy_defs(scope=None):
          * ``"description"``, a human-readable description of the section
      * ``"comparators"``, containing a dictionary mapping each comparator to a dictionary with the following keys:
          * ``"description"``, a human-readable description of the comparator
+     * ``"unsetOptions"``, containing a dictionary mapping each option how to react to an unset value to a dictionary with the following keys:
+         * ``"description"``, a human-readable description of the option
+
 
     if the scope is "edumfanodes", it returns a list of the configured eduMFA nodes.
 
@@ -544,9 +548,11 @@ def get_policy_defs(scope=None):
         # special treatment: get descriptions of conditions
         section_descriptions = get_policy_condition_sections()
         comparator_descriptions = get_policy_condition_comparators()
+        unset_descriptions = get_policy_condition_unset_options()
         result = {
             "sections": section_descriptions,
             "comparators": comparator_descriptions,
+            "unsetOptions": unset_descriptions,
         }
     elif scope == 'edumfanodes':
         result = get_edumfa_nodes()

--- a/edumfa/lib/policy.py
+++ b/edumfa/lib/policy.py
@@ -316,6 +316,7 @@ class ACTION(object):
     SERVICEID_DELETE = "serviceid_delete"
     PREFERREDCLIENTMODE = "preferred_client_mode"
     REQUIRE_DESCRIPTION = "require_description"
+    TOKEN_ASK_DELETE = "token_ask_delete"
 
 
 class TYPE(object):
@@ -2547,6 +2548,11 @@ def get_static_policy_definitions(scope=None):
                 'desc': _("This action adds a QR code in the enrollment page for "
                           "HOTP, TOTP and Push tokens, that lead to this given URL."),
                 'group': 'QR Codes'
+            },
+            ACTION.TOKEN_ASK_DELETE: {
+                'type': 'str',
+                'desc': _('This is a whitespace separated list of tokentypes, '
+                          'for which a the deletion has to be confirmed. '),
             }
         }
 

--- a/edumfa/lib/policy.py
+++ b/edumfa/lib/policy.py
@@ -108,7 +108,7 @@ from edumfa.lib.radiusserver import get_radiusservers
 from edumfa.lib.utils import (check_time_in_range, check_pin_contents,
                                    fetch_one_resource, is_true, check_ip_in_policy,
                                    determine_logged_in_userparams, parse_string_to_dict)
-from edumfa.lib.utils.compare import compare_values, COMPARATOR_DESCRIPTIONS
+from edumfa.lib.utils.compare import compare_values, COMPARATOR_DESCRIPTIONS, UNSET, UNSET_DESCRIPTIONS
 from edumfa.lib.utils.export import (register_import, register_export)
 from edumfa.lib.user import User
 from edumfa.lib import _
@@ -728,37 +728,42 @@ class PolicyClass(object):
         dbtoken = None
         for policy in policies:
             include_policy = True
-            for section, key, comparator, value, active in policy['conditions']:
+
+            #migrate to new condition format
+            if len(policy['conditions']) == 5:
+                policy['conditions'].append("exception")
+
+            for section, key, comparator, value, active, unset in policy['conditions']:
                 if (extended_condition_check is CONDITION_CHECK.CHECK_AND_RAISE_EXCEPTION_ON_MISSING
                         or section in extended_condition_check):
                     # We check conditions, either if we are supposed to check everything or if
                     # the section is contained in the extended condition check
                     if active:
                         if section == CONDITION_SECTION.USERINFO:
-                            if not self._policy_matches_info_condition(policy, key, comparator, value,
+                            if not self._policy_matches_info_condition(policy, key, comparator, value, unset, 
                                                                        CONDITION_SECTION.USERINFO,
                                                                        user_object=user_object):
                                 include_policy = False
                                 break
                         elif section == CONDITION_SECTION.TOKENINFO:
                             dbtoken = dbtoken or Token.query.filter(Token.serial == serial).first() if serial else None
-                            if not self._policy_matches_info_condition(policy, key, comparator, value,
+                            if not self._policy_matches_info_condition(policy, key, comparator, value, unset, 
                                                                        CONDITION_SECTION.TOKENINFO,
                                                                        dbtoken=dbtoken):
                                 include_policy = False
                                 break
                         elif section == CONDITION_SECTION.TOKEN:
                             dbtoken = dbtoken or Token.query.filter(Token.serial == serial).first() if serial else None
-                            if not self._policy_matches_token_condition(policy, key, comparator, value, dbtoken):
+                            if not self._policy_matches_token_condition(policy, key, comparator, value, unset, dbtoken):
                                 include_policy = False
                                 break
                         elif section == CONDITION_SECTION.HTTP_REQUEST_HEADER:
-                            if not self._policy_matches_request_header_condition(policy, key, comparator, value,
+                            if not self._policy_matches_request_header_condition(policy, key, comparator, value, unset, 
                                                                                  request_headers):
                                 include_policy = False
                                 break
                         elif section == CONDITION_SECTION.HTTP_ENVIRONMENT:
-                            if not self._policy_matches_request_environ_condition(policy, key, comparator, value,
+                            if not self._policy_matches_request_environ_condition(policy, key, comparator, unset, value, unset, 
                                                                                  request_headers):
                                 include_policy = False
                                 break
@@ -772,7 +777,7 @@ class PolicyClass(object):
         return reduced_policies
 
     @staticmethod
-    def _policy_matches_request_environ_condition(policy, key, comparator, value, request_headers):
+    def _policy_matches_request_environ_condition(policy, key, comparator, value, unset, request_headers):
         """
         :param request_headers: Request Header object
         :type request_headers: Can be accessed using .get()
@@ -790,11 +795,8 @@ class PolicyClass(object):
                     raise PolicyError(
                         "Invalid comparison in the HTTP environment conditions of policy {!r}".format(policy['name']))
             else:
-                log.warning("Unknown HTTP environment key referenced in condition of policy "
-                            "{!r}: {!r}".format(policy["name"], key))
-                log.warning("Available HTTP environment: {!r}".format(request_environ))
-                raise PolicyError("Unknown HTTP environment key referenced in condition of policy "
-                                  "{!r}: {!r}".format(policy["name"], key))
+                return PolicyClass._react_to_unset(unset, "Unknown HTTP environment key referenced in condition of policy {!r}: {!r}".format(policy["name"], key))
+
         else:  # pragma: no cover
             log.error("Policy {!r} has conditions on HTTP environment, but HTTP environment"
                       " is not available. This should not happen - possible "
@@ -822,11 +824,8 @@ class PolicyClass(object):
                     raise PolicyError(
                         "Invalid comparison in the HTTP header conditions of policy {!r}".format(policy['name']))
             else:
-                log.warning("Unknown HTTP header key referenced in condition of policy "
-                            "{!r}: {!r}".format(policy["name"], key))
-                log.warning("Available HTTP headers: {!r}".format(request_headers))
-                raise PolicyError("Unknown HTTP header key referenced in condition of policy "
-                                  "{!r}: {!r}".format(policy["name"], key))
+                return PolicyClass._react_to_unset(unset, u"Unknown HTTP header key referenced in condition of policy {!r}: {!r}".format(policy["name"], key))
+        
         else:  # pragma: no cover
             log.error("Policy {!r} has conditions on HTTP headers, but HTTP header"
                       " is not available. This should not happen - possible "
@@ -836,7 +835,7 @@ class PolicyClass(object):
                               " is not available".format(policy["name"], key))
 
     @staticmethod
-    def _policy_matches_token_condition(policy, key, comparator, value, db_token):
+    def _policy_matches_token_condition(policy, key, comparator, value, unet, db_token):
         """
         This extended policy checks for token attributes, which are existing columns in
         the token DB table.
@@ -871,7 +870,7 @@ class PolicyClass(object):
                               " is not available".format(policy["name"]))
 
     @staticmethod
-    def _policy_matches_info_condition(policy, key, comparator, value, type, user_object=None, dbtoken=None):
+    def _policy_matches_info_condition(policy, key, comparator, value, unset, type, user_object=None, dbtoken=None):
         """
         Check if the given policy matches a certain userinfo or tokeninfo condition depending
         on the specified ``type``.
@@ -901,25 +900,28 @@ class PolicyClass(object):
                     raise PolicyError(
                         "Invalid comparison in the {!s} conditions of policy {!r}".format(type, policy['name']))
             else:
-                log.warning("Unknown {!s} key referenced in a condition of policy {!r}: {!r}".format(
-                    type, policy['name'], key
-                ))
                 # If we do have an user or token object, but the conditions of policies reference
-                # an unknown userinfo or tokeninfo key, we have a misconfiguration and raise an error.
-                raise PolicyError("Unknown key in the {!s} conditions of policy {!r}".format(
-                    type, policy['name']
-                ))
+                # an unknown userinfo or tokeninfo key, we react as configured.
+                return PolicyClass._react_to_unset(unset, "Unknown {!s} key referenced in a condition of policy {!r}: {!r}".format(type, policy['name'], key))
+
         else:
-            log.error("Policy {!r} has condition on {!s}, but the according object"
-                      " is not available - possible programming error "
-                      "{!s}.".format(policy['name'], type, ''.join(traceback.format_stack())))
             # If the policy specifies a userinfo or tokeninfo condition, but no object is available,
-            # the policy is misconfigured. We have to raise a PolicyError to ensure that
-            # the eduMFA server does not silently misbehave.
-            raise PolicyError(
-                "Policy {!r} has condition on {!s}, but an according object is not available".format(
-                    policy['name'], type
-                ))
+            # we react as configured.
+            return PolicyClass._react_to_unset(unset, "Policy {!r} has condition on {!s}, but an according object is not available".format(policy['name'], type))
+
+    @staticmethod
+    def _react_to_unset(unset, message):
+        """
+        This function returns the configured reaction if a value is not defined.
+        The message is set as the message of the exception if unset is UNSET.EXEPTION
+        """
+        if unset == UNSET.TRUE:
+            return True
+        elif unset == UNSET.FALSE:
+            return False
+        else:
+            log.warning(message)
+            raise PolicyError(message)
 
     @staticmethod
     def check_for_conflicts(policies, action):
@@ -1250,7 +1252,7 @@ def set_policy(name=None, scope=None, action=None, realm=None, resolver=None,
     :param check_all_resolvers: If all the resolvers of a user should be
         checked with this policy
     :type check_all_resolvers: bool
-    :param conditions: A list of 5-tuples (section, key, comparator, value, active) of policy conditions
+    :param conditions: A list of 6-tuples (section, key, comparator, value, active, unset) of policy conditions
     :param edumfanode: A eduMFA node or a list of eduMFA nodes.
     :return: The database ID od the the policy
     :rtype: int
@@ -1295,14 +1297,15 @@ def set_policy(name=None, scope=None, action=None, realm=None, resolver=None,
     # validate conditions parameter
     if conditions is not None:
         for condition in conditions:
-            if len(condition) != 5:
-                raise ParameterError("Conditions must be 5-tuples: {!r}".format(condition))
+            if len(condition) != 6:
+                raise ParameterError("Conditions must be 6-tuples: {!r}".format(condition))
             if not (isinstance(condition[0], str)
                     and isinstance(condition[1], str)
                     and isinstance(condition[2], str)
                     and isinstance(condition[3], str)
-                    and isinstance(condition[4], bool)):
-                raise ParameterError("Conditions must be 5-tuples of four strings and one boolean: {!r}".format(
+                    and isinstance(condition[4], bool)
+                    and isinstance(condition[5], str)):
+                raise ParameterError("Conditions must be 6-tuples of four strings, one boolean and another string: {!r}".format(
                     condition))
     p1 = Policy.query.filter_by(name=name).first()
     if p1:
@@ -2620,6 +2623,13 @@ def get_policy_condition_comparators():
     return {comparator: {"description": description}
             for comparator, description in COMPARATOR_DESCRIPTIONS.items()}
 
+def get_policy_condition_unset_options():
+    """
+    :return: a dictionary mapping each option how to react to an unset value to a dictionary with the following keys
+     * ``"description"``, a human-readable description of the option
+    """
+    return {comparator: {"description": description}
+            for comparator, description in UNSET_DESCRIPTIONS.items()}
 
 class MatchingError(ServerError):
     pass

--- a/edumfa/lib/policy.py
+++ b/edumfa/lib/policy.py
@@ -763,7 +763,7 @@ class PolicyClass(object):
                                 include_policy = False
                                 break
                         elif section == CONDITION_SECTION.HTTP_ENVIRONMENT:
-                            if not self._policy_matches_request_environ_condition(policy, key, comparator, unset, value, unset, 
+                            if not self._policy_matches_request_environ_condition(policy, key, comparator, value, unset, 
                                                                                  request_headers):
                                 include_policy = False
                                 break
@@ -806,7 +806,7 @@ class PolicyClass(object):
                               " is not available".format(policy["name"], key))
 
     @staticmethod
-    def _policy_matches_request_header_condition(policy, key, comparator, value, request_headers):
+    def _policy_matches_request_header_condition(policy, key, comparator, value, unset, request_headers):
         """
         :param request_headers: Request Header object
         :type request_headers: Can be accessed using .get()
@@ -835,7 +835,7 @@ class PolicyClass(object):
                               " is not available".format(policy["name"], key))
 
     @staticmethod
-    def _policy_matches_token_condition(policy, key, comparator, value, unet, db_token):
+    def _policy_matches_token_condition(policy, key, comparator, value, unset, db_token):
         """
         This extended policy checks for token attributes, which are existing columns in
         the token DB table.

--- a/edumfa/lib/utils/compare.py
+++ b/edumfa/lib/utils/compare.py
@@ -208,6 +208,21 @@ COMPARATOR_DESCRIPTIONS = {
 }
 
 
+#: This class enumerates all available options on how to react if a value is not set.
+class UNSET(object):
+    EXCEPTION = "exception"
+    FALSE = "false"
+    TRUE = "true"
+
+
+#: This dictionary connects options to their human-readable (and translated) descriptions.
+UNSET_DESCRIPTIONS = {
+    UNSET.EXCEPTION: _("return true if the value is not set"),
+    UNSET.FALSE: _("return false if the value is not set"),
+    UNSET.TRUE: _("throw an exception if the value is not set"),
+}
+
+
 def compare_values(left, comparator, right):
     """
     Compare two values according to ``comparator`` and return either True or False.

--- a/edumfa/models.py
+++ b/edumfa/models.py
@@ -1551,12 +1551,12 @@ class Policy(TimestampMethodsMixin, db.Model):
     def set_conditions(self, conditions):
         """
         Replace the list of conditions of this policy with a new list
-        of conditions, i.e. a list of 5-tuples (section, key, comparator, value, active).
+        of conditions, i.e. a list of 6-tuples (section, key, comparator, value, active, unset).
         """
         self.conditions = []
-        for section, key, comparator, value, active in conditions:
+        for section, key, comparator, value, active, unset in conditions:
             condition_object = PolicyCondition(
-                section=section, Key=key, comparator=comparator, Value=value, active=active,
+                section=section, Key=key, comparator=comparator, Value=value, active=active, unset=unset
             )
             self.conditions.append(condition_object)
 
@@ -1632,14 +1632,15 @@ class PolicyCondition(MethodsMixin, db.Model):
     comparator = db.Column(db.Unicode(255), nullable=False, default='equals')
     Value = db.Column(db.Unicode(2000), nullable=False, default='')
     active = db.Column(db.Boolean, nullable=False, default=True)
+    undef = db.Column(db.Unicode(255), nullable=False, default=u'exception')
 
     __table_args__ = {'mysql_row_format': 'DYNAMIC'}
 
     def as_tuple(self):
         """
-        :return: the condition as a tuple (section, key, comparator, value, active)
+        :return: the condition as a tuple (section, key, comparator, value, active, unset)
         """
-        return self.section, self.Key, self.comparator, self.Value, self.active
+        return self.section, self.Key, self.comparator, self.Value, self.active, self.undef
 
 
 # ------------------------------------------------------------------

--- a/edumfa/static/components/directives/controllers/directives.js
+++ b/edumfa/static/components/directives/controllers/directives.js
@@ -469,7 +469,7 @@ myApp.directive("piPolicyConditions", ["instanceUrl", "versioningSuffixProvider"
         restrict: 'E',
         scope: {
             // We need a bidirectional binding because we modify the conditions.
-            // The conditions are a list of 5-element lists.
+            // The conditions are a list of 6-element lists.
             policyConditions: "=conditions",
             // We only need a one-directional binding, because we will never change the definitions
             conditionDefs: "=defs"
@@ -501,7 +501,7 @@ myApp.directive("piPolicyConditions", ["instanceUrl", "versioningSuffixProvider"
             // Called when the user clicks on the "add condition" button.
             // Adds a condition with default values
             scope.addCondition = function () {
-                scope.policyConditions.push(["userinfo", "", "equals", "", false]);
+                scope.policyConditions.push(["userinfo", "", "equals", "", false, "exception"]);
                 scope.editIndex = scope.policyConditions.length - 1;
             };
         },

--- a/edumfa/static/components/directives/views/directive.policyconditions.html
+++ b/edumfa/static/components/directives/views/directive.policyconditions.html
@@ -7,6 +7,7 @@
             <th translate>Key</th>
             <th translate>Comparator</th>
             <th translate>Value</th>
+            <th translate>If Unset</th>
         </tr>
         </thead>
         <tr ng-repeat="condition in policyConditions">
@@ -48,6 +49,16 @@
                <span ng-show="editIndex != $index"><code>{{ condition[3] }}</code></span>
                <span ng-show="editIndex == $index">
                    <input type="text" ng-model="condition[3]" class="form-control" />
+               </span>
+           </td>
+	   <td>
+               <span ng-show="editIndex != $index"><code>{{ condition[5] }}</code></span>
+               <span ng-show="editIndex == $index">
+		   <select ng-model="condition[5]" class="form-control">
+                       <option ng-repeat="(key, value) in conditionDefs.unsetOptions"
+                               ng-value="key"
+                               title="{{ value.description }}">{{ key }}</option>
+                   </select>
                </span>
            </td>
            <td style="text-align: right;">

--- a/edumfa/static/components/login/controllers/loginControllers.js
+++ b/edumfa/static/components/login/controllers/loginControllers.js
@@ -468,6 +468,7 @@ angular.module("eduMfaApp")
             $scope.token_rollover = data.result.value.token_rollover;
             $scope.subscription_state = data.result.value.subscription_status;
             $scope.subscription_state_push = data.result.value.subscription_status_push;
+            $scope.token_ask_delete = data.result.value.token_ask_delete;
             $rootScope.search_on_enter = data.result.value.search_on_enter;
             // Token specific settings
             $scope.tokensettings = {indexedsecret:

--- a/edumfa/static/components/token/controllers/tokenDetailController.js
+++ b/edumfa/static/components/token/controllers/tokenDetailController.js
@@ -230,8 +230,9 @@ myApp.controller("tokenDetailController", ['$scope', 'TokenFactory',
     };
 
     $scope.deleteTokenAsk = function() {
-        var tokenType = $scope.token.info.tokenkind;
-        if (tokenType == "hardware"){
+        var tokenKind = $scope.token.info.tokenkind;
+        var typeType = $scope.token.tokentype;
+        if (tokenKind == "hardware" || typeType in $scope.token_ask_delete ){
             $('#dialogTokenDelete').modal();
         } else {
             $scope.delete();


### PR DESCRIPTION
Hi,

dieser PR enthält zwei Änderungen

1. Es gibt eine neue Option "token_ask_delete" in der WEBUI Policy. Dort kann man eine Liste von Tokentypen angeben. Bei diesen wird die Nutzer*in beim löschen um Bestätigung gebeten.
2. Ein neuer Comperator  für die tokeninfo um zu prüfen ob diese überhaupt gesetzt sind.

Diese Änderungen hatte ich schon zwei mal ([!3511](https://github.com/privacyidea/privacyidea/pull/3511) und [!3513](https://github.com/privacyidea/privacyidea/pull/3513)) im upstream Projekt vorgeschlagen aber bis jetzt sind sie noch nicht aufgenommen.

Ich würde das gerne erledigt haben bevor ich migriere. Dann kann ich mir den Patch beim installieren sparen.

Doku kann ich gerne nachziehen wenn du mit der inhaltlichen Änderung soweit zufrieden bist.

mfg
Clemens