### PR TITLE
fix: rename provider module names in DB on migration

### DIFF
--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -47,3 +47,4 @@ The latest migration will rename several columns and tables from privacyIDEA rel
     * Replace all occurences of `login_mode=privacyIDEA` in `policy.action` with `login_mode=eduMFA`
     * Replace all occurences of `privacyideaserver_read` in `policy.action` with `edumfaserver_read`
     * Replace all occurences of `privacyideaserver_write` in `policy.action` with `edumfaserver_write`
+    * Replace all occurences of `privacyidea.` in `smsgateway.providermodule` with `edumfa.`

--- a/migrations/versions/0d011e94a8e8_.py
+++ b/migrations/versions/0d011e94a8e8_.py
@@ -9,7 +9,7 @@ from sqlalchemy import orm
 from alembic import op, context
 import sqlalchemy as sa
 
-from edumfa.models import Policy
+from edumfa.models import Policy, SMSGateway
 
 # revision identifiers, used by Alembic.
 revision = '0d011e94a8e8'
@@ -73,6 +73,17 @@ def upgrade():
         print("Failed to update admin policy!")
         print(e)
 
+    session = orm.Session(bind=bind)
+    try:
+        for row in session.query(SMSGateway).filter(SMSGateway.providermodule.like("privacyidea.lib.%")):
+            row.providermodule = row.providermodule.replace("privacyidea.lib.", "edumfa.lib.")
+        session.commit()
+    except Exception as e:
+        session.rollback()
+        print("Failed to update SmsGateway providermodules!")
+        print(e)
+
+
 
 def downgrade():
     try:
@@ -125,4 +136,14 @@ def downgrade():
     except Exception as e:
         session.rollback()
         print("Failed to update admin policy!")
+        print(e)
+
+    session = orm.Session(bind=bind)
+    try:
+        for row in session.query(SMSGateway).filter(SMSGateway.providermodule.like("edumfa.lib.%")):
+            row.providermodule = row.providermodule.replace("edumfa.lib.", "privacyidea.lib.")
+        session.commit()
+    except Exception as e:
+        session.rollback()
+        print("Failed to update SmsGateway providermodules!")
         print(e)


### PR DESCRIPTION
in table *smsgateway* the column *providermodule* may contain module names like `privacyidea.lib.smsprovider.HttpSMSProvider.HttpSMSProvider`, rename those to `edumfa.lib.xxx`