### PR TITLE
feat: api: set tokeninfo on init

### DIFF
--- a/edumfa/api/token.py
+++ b/edumfa/api/token.py
@@ -162,7 +162,7 @@ def init():
                             hex or base32check (see :ref:`2step_enrollment`)
     :jsonparam rollover: Set this to 1 or true to indicate, that you want to rollover a token.
                     This is mandatory to rollover tokens, that are in the clientwait state.
-    :jsonparam dict info: dictionary with key value pairs which will be set as tokeninfo.
+    :jsonparam info: string representation of a json object whose key-value pairs will be set as tokeninfo.
 
     :return: a json result with a boolean "result": true
 

--- a/edumfa/api/token.py
+++ b/edumfa/api/token.py
@@ -162,6 +162,7 @@ def init():
                             hex or base32check (see :ref:`2step_enrollment`)
     :jsonparam rollover: Set this to 1 or true to indicate, that you want to rollover a token.
                     This is mandatory to rollover tokens, that are in the clientwait state.
+    :jsonparam dict info: dictionary with key value pairs which will be set as tokeninfo.
 
     :return: a json result with a boolean "result": true
 
@@ -1214,7 +1215,7 @@ def modify_tokeninfo_api(serial):
     with the same key are overwritten, keys with null value are deleted
 
     :jsonparam dict info: dictionary with key value pairs. keys with null value are deleted. always make sure not to
-    : include keys with null value by accident!
+    include keys with null value by accident!
     :param serial: the serial number/identifier of the token
     :return: returns value=True in case at least one token matching the serial could be found
     :rtype: bool

--- a/edumfa/lib/token.py
+++ b/edumfa/lib/token.py
@@ -33,7 +33,7 @@ tokenclass implementations like lib.tokens.hotptoken)
 
 This is the middleware/glue between the HTTP API and the database
 """
-
+import json
 import traceback
 import string
 import datetime
@@ -1054,6 +1054,8 @@ def init_token(param, user=None, tokenrealms=None,
     if user and user.realm:
         realms.append(user.realm)
 
+
+
     try:
         # Save the token to the database
         if token_count == 0:
@@ -1090,6 +1092,18 @@ def init_token(param, user=None, tokenrealms=None,
     # In all other cases it is set in the update method of the tokenclass.
     if tokenkind:
         tokenobject.add_tokeninfo("tokenkind", tokenkind)
+
+    #Set tokeninfo from info dict
+    tokeninfo = param.get("info")
+    if tokeninfo:
+        if type(tokeninfo) is not dict:
+            tokeninfo = json.loads(tokeninfo)
+        if type(tokeninfo) is not dict:
+            raise ParameterError("Parameter 'info' must be a list of key, value pairs (dictionary). but is of type {0!r}", type(tokeninfo))
+        else:
+            for key, value in tokeninfo.items():
+                if value:
+                    tokenobject.add_tokeninfo(key, value)
 
     # Set the validity period
     validity_period_start = param.get("validity_period_start")

--- a/edumfa/lib/token.py
+++ b/edumfa/lib/token.py
@@ -995,7 +995,8 @@ def init_token(param, user=None, tokenrealms=None,
             {
                 "serial": ..., (optional)
                 "type": ...., (optional, default=hotp)
-                "otpkey": ...
+                "otpkey": ...,
+                "info": ... (optional)
             }
 
     :type param: dict
@@ -1054,6 +1055,14 @@ def init_token(param, user=None, tokenrealms=None,
     if user and user.realm:
         realms.append(user.realm)
 
+    # Check tokeninfo parameter
+    tokeninfo = param.get("info")
+    if tokeninfo:
+        if type(tokeninfo) is not dict:
+            tokeninfo = json.loads(tokeninfo)
+        if type(tokeninfo) is not dict:
+            raise ParameterError("Parameter 'info' must be a string representation of a json object (key-value pairs) or a python dict. but is of type {0!r}", type(tokeninfo))
+
     try:
         # Save the token to the database
         if token_count == 0:
@@ -1091,17 +1100,11 @@ def init_token(param, user=None, tokenrealms=None,
     if tokenkind:
         tokenobject.add_tokeninfo("tokenkind", tokenkind)
 
-    # Set tokeninfo from info dict
-    tokeninfo = param.get("info")
+    # Set tokeninfo
     if tokeninfo:
-        if type(tokeninfo) is not dict:
-            tokeninfo = json.loads(tokeninfo)
-        if type(tokeninfo) is not dict:
-            raise ParameterError("Parameter 'info' must be a list of key, value pairs (dictionary). but is of type {0!r}", type(tokeninfo))
-        else:
-            for key, value in tokeninfo.items():
-                if value:
-                    tokenobject.add_tokeninfo(key, value)
+        for key, value in tokeninfo.items():
+            if value:
+                tokenobject.add_tokeninfo(key, value)
 
     # Set the validity period
     validity_period_start = param.get("validity_period_start")

--- a/edumfa/lib/token.py
+++ b/edumfa/lib/token.py
@@ -1054,8 +1054,6 @@ def init_token(param, user=None, tokenrealms=None,
     if user and user.realm:
         realms.append(user.realm)
 
-
-
     try:
         # Save the token to the database
         if token_count == 0:
@@ -1093,7 +1091,7 @@ def init_token(param, user=None, tokenrealms=None,
     if tokenkind:
         tokenobject.add_tokeninfo("tokenkind", tokenkind)
 
-    #Set tokeninfo from info dict
+    # Set tokeninfo from info dict
     tokeninfo = param.get("info")
     if tokeninfo:
         if type(tokeninfo) is not dict:

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -320,6 +320,11 @@ class TokenTestCase(MyTestCase):
         self.assertRaises(TokenAdminError, init_token, {"otpkey": "1234",
                                                         "type": "never_know"})
 
+        # try to create invalid tokeninfo
+        self.assertRaises(ParameterError, init_token, {"otpkey": "1234",
+                                                        "type": "totp",
+                                                        "info": "[1,2,3,4]"})
+
         # try to create the same token with another type
         self.assertRaises(TokenAdminError, init_token, {"otpkey": "1234",
                                                         "serial": "NEW001",


### PR DESCRIPTION
in api function token/init/ add optional parameter **"info"**, which can contain a json object whose key-value pairs will be set as tokeninfo for the new token.
this might significantly reduce the amount of requests needed in some scenarios.