### PR TITLE
fix: correct location of venv for ubuntu packages

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -56,6 +56,8 @@ jobs:
           sudo apt update
           sudo apt install -y build-essential debhelper devscripts equivs dh-virtualenv
       - name: Build core package
+        env:
+          DH_VIRTUALENV_INSTALL_ROOT: /opt
         run: |
           mv deploy/ubuntu debian
           sed -i 's/{{CODENAME}}/focal/g' debian/changelog

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -15,6 +15,8 @@ jobs:
           sudo apt update
           sudo apt install -y build-essential debhelper devscripts equivs dh-virtualenv
       - name: Build core package
+        env:
+          DH_VIRTUALENV_INSTALL_ROOT: /opt
         run: |
           mv deploy/ubuntu debian
           sed -i 's/{{CODENAME}}/jammy/g' debian/changelog


### PR DESCRIPTION
This PR fixes the core package (edumfa). DH Virtualvenv defaults for the `/opt/venv/<project>` installation path. However in our case we require it to be installed in `/opt/<project>`.

With the `DH_VIRTUALENV_INSTALL_ROOT` Env variable set, this will work as initially intended.