### PR TITLE
chore: do not inherit from `object`

### DIFF
--- a/edumfa/api/lib/postpolicy.py
+++ b/edumfa/api/lib/postpolicy.py
@@ -70,7 +70,7 @@ DEFAULT_POLICY_TEMPLATE_URL = "https://raw.githubusercontent.com/edumfa/" \
                               "policy-templates/main/templates/"
 
 
-class postpolicy(object):
+class postpolicy:
     """
     Decorator that allows one to call a specific function after the decorated
     function.
@@ -104,7 +104,7 @@ class postpolicy(object):
         return policy_wrapper
 
 
-class postrequest(object):
+class postrequest:
     """
     Decorator that is supposed to be used with after_request.
     """

--- a/edumfa/api/lib/prepolicy.py
+++ b/edumfa/api/lib/prepolicy.py
@@ -90,7 +90,7 @@ optional = True
 required = False
 
 
-class prepolicy(object):
+class prepolicy:
     """
     This is the decorator wrapper to call a specific function before an API
     call.

--- a/edumfa/config.py
+++ b/edumfa/config.py
@@ -38,7 +38,7 @@ def _random_password(size):
     return "".join(passwd)
 
 
-class Config(object):
+class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY')
     # SQL_ALCHEMY_DATABASE_URI = "mysql://privacyidea:XmbSrlqy5d4IS08zjz"
     # "GG5HTt40Cpf5@localhost/privacyidea"

--- a/edumfa/lib/applications/base.py
+++ b/edumfa/lib/applications/base.py
@@ -75,7 +75,7 @@ def get_machine_application_class_dict():
     return ret
 
 
-class MachineApplication(object):
+class MachineApplication:
 
     application_name = "base"
     '''If bulk_call is false, the administrator may

--- a/edumfa/lib/auditmodules/base.py
+++ b/edumfa/lib/auditmodules/base.py
@@ -55,7 +55,7 @@ import datetime
 log = logging.getLogger(__name__)
 
 
-class Paginate(object):
+class Paginate:
     """
     This is a pagination object, that is used for searching audit trails.
     """
@@ -73,7 +73,7 @@ class Paginate(object):
         self.total = 0
     
 
-class Audit(object):  # pragma: no cover
+class Audit:  # pragma: no cover
 
     is_readable = False
 

--- a/edumfa/lib/auth.py
+++ b/edumfa/lib/auth.py
@@ -33,7 +33,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class ROLE(object):
+class ROLE:
     ADMIN = "admin"
     USER = "user"
     VALIDATE = "validate"

--- a/edumfa/lib/caconnectors/baseca.py
+++ b/edumfa/lib/caconnectors/baseca.py
@@ -32,7 +32,7 @@ This module is tested in tests/test_lib_caconnector.py
 AvailableCAConnectors = []
 
 
-class BaseCAConnector(object):
+class BaseCAConnector:
     def revoke_cert(self, certificate, request_id=None, reason=None):
         """
         Revoke the specified certificate. At this point only the database

--- a/edumfa/lib/caconnectors/caservice_pb2_grpc.py
+++ b/edumfa/lib/caconnectors/caservice_pb2_grpc.py
@@ -5,7 +5,7 @@ import grpc
 import eduMFA.lib.caconnectors.caservice_pb2 as caservice__pb2
 
 
-class CAServiceStub(object):
+class CAServiceStub:
     """Disposition values:
     0 - Incomplete
     1 - Error
@@ -59,7 +59,7 @@ class CAServiceStub(object):
                 )
 
 
-class CAServiceServicer(object):
+class CAServiceServicer:
     """Disposition values:
     0 - Incomplete
     1 - Error
@@ -157,7 +157,7 @@ def add_CAServiceServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class CAService(object):
+class CAService:
     """Disposition values:
     0 - Incomplete
     1 - Error

--- a/edumfa/lib/caconnectors/localca.py
+++ b/edumfa/lib/caconnectors/localca.py
@@ -212,7 +212,7 @@ def _get_crl_next_update(filename):
     return dt
 
 
-class CONFIG(object):
+class CONFIG:
 
     def __init__(self, name):
         self.directory = "./ca"
@@ -238,7 +238,7 @@ class CONFIG(object):
         return s
 
 
-class ATTR(object):
+class ATTR:
     __doc__ = """This is the list Attributes of the Local CA."""
     CAKEY = "cakey"
     CACERT = "cacert"

--- a/edumfa/lib/caconnectors/msca.py
+++ b/edumfa/lib/caconnectors/msca.py
@@ -56,7 +56,7 @@ CRL_REASONS = ["unspecified", "keyCompromise", "CACompromise",
 TIMEOUT = 3
 
 
-class CONFIG(object):  # pragma: no cover
+class CONFIG:  # pragma: no cover
     # Only needed for command line creation
 
     def __init__(self, name):
@@ -81,7 +81,7 @@ class CONFIG(object):  # pragma: no cover
         return s
 
 
-class ATTR(object):
+class ATTR:
     __doc__ = """This is the list Attributes of the Microsoft CA connector."""
     HOSTNAME = "hostname"
     PORT = "port"

--- a/edumfa/lib/challengeresponsedecorators.py
+++ b/edumfa/lib/challengeresponsedecorators.py
@@ -45,7 +45,7 @@ log = logging.getLogger(__name__)
 SEED_LENGTH = 16
 
 
-class CHALLENGE_TYPE(object):
+class CHALLENGE_TYPE:
     PIN_RESET = "generic_pin_reset"
     RESYNC = "generic_resync"
 

--- a/edumfa/lib/config.py
+++ b/edumfa/lib/config.py
@@ -62,7 +62,7 @@ this = sys.modules[__name__]
 this.config = {}
 
 
-class SharedConfigClass(object):
+class SharedConfigClass:
     """
     A shared config class object is shared between threads and is supposed
     to store the current configuration with resolvers, realms, policies
@@ -198,7 +198,7 @@ class SharedConfigClass(object):
         return self._clone()
 
 
-class LocalConfigClass(object):
+class LocalConfigClass:
     """
     The Config_Object will contain all database configuration of system
     config, resolvers, realms, policies and event handler definitions.
@@ -270,7 +270,7 @@ class LocalConfigClass(object):
         return r_config
 
 
-class SYSCONF(object):
+class SYSCONF:
     __doc__ = """This is a list of system config attributes"""
     OVERRIDECLIENT = "OverrideAuthorizationClient"
     PREPENDPIN = "PrependPin"

--- a/edumfa/lib/crypto.py
+++ b/edumfa/lib/crypto.py
@@ -85,7 +85,7 @@ FAILED_TO_DECRYPT_PASSWORD = "FAILED TO DECRYPT PASSWORD!"  # nosec B105 # place
 log = logging.getLogger(__name__)
 
 
-class SecretObj(object):
+class SecretObj:
     def __init__(self, val, iv, preserve=True):
         self.val = val
         self.iv = iv
@@ -503,7 +503,7 @@ def geturandom(length=20, hex=False):
 # some random functions based on geturandom #################################
 
 
-class urandom(object):
+class urandom:
 
     precision = 12
 
@@ -681,7 +681,7 @@ def _slow_rsa_verify_raw(key, sig, msg):
     return msg == pow(sig, pn.e, pn.n)
 
 
-class Sign(object):
+class Sign:
     """
     Signing class that is used to sign Audit Entries and to sign API responses.
     """

--- a/edumfa/lib/decorators.py
+++ b/edumfa/lib/decorators.py
@@ -78,7 +78,7 @@ def check_user_or_serial(func):
     return user_or_serial_wrapper
 
 
-class check_user_or_serial_in_request(object):
+class check_user_or_serial_in_request:
     """
     Decorator to check user and serial in a request.
     If the request does not contain a serial number (serial) or a user

--- a/edumfa/lib/edumfaserver.py
+++ b/edumfa/lib/edumfaserver.py
@@ -42,7 +42,7 @@ This module is tested in tests/test_lib_edumfaserver.py
 log = logging.getLogger(__name__)
 
 
-class eduMFAServer(object):
+class eduMFAServer:
     """
     eduMFA Server object with configuration. The eduMFA Server object
     contains a test functionality so that the configuration can be tested.

--- a/edumfa/lib/event.py
+++ b/edumfa/lib/event.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 AVAILABLE_EVENTS = []
 
 
-class event(object):
+class event:
     """
     This is the event decorator that calls the event handler in the handler
     module. This event decorator can be used at any API call
@@ -257,7 +257,7 @@ def delete_event(event_id):
     return fetch_one_resource(EventHandler, id=event_id).delete()
 
 
-class EventConfiguration(object):
+class EventConfiguration:
     """
     This class is supposed to contain the event handling configuration during
     the Request.

--- a/edumfa/lib/eventhandler/base.py
+++ b/edumfa/lib/eventhandler/base.py
@@ -50,7 +50,7 @@ from edumfa.lib.tokenclass import DATE_FORMAT
 log = logging.getLogger(__name__)
 
 
-class CONDITION(object):
+class CONDITION:
     """
     Possible conditions
     """
@@ -79,7 +79,7 @@ class CONDITION(object):
     ROLLOUT_STATE = "rollout_state"
 
 
-class GROUP(object):
+class GROUP:
     """
     These are the event handler groups. The conditions
     will be grouped in the UI.
@@ -90,7 +90,7 @@ class GROUP(object):
     COUNTER = "counter"
 
 
-class BaseEventHandler(object):
+class BaseEventHandler:
     """
     An Eventhandler needs to return a list of actions, which it can handle.
 

--- a/edumfa/lib/eventhandler/customuserattributeshandler.py
+++ b/edumfa/lib/eventhandler/customuserattributeshandler.py
@@ -12,7 +12,7 @@ from edumfa.lib.user import User
 log = logging.getLogger(__name__)
 
 
-class ACTION_TYPE(object):
+class ACTION_TYPE:
     """
     Allowed actions
     """
@@ -20,7 +20,7 @@ class ACTION_TYPE(object):
     DELETE_CUSTOM_USER_ATTRIBUTES = "delete_custom_user_attributes"
 
 
-class USER_TYPE(object):
+class USER_TYPE:
     """
     Allowed user types
     """

--- a/edumfa/lib/eventhandler/federationhandler.py
+++ b/edumfa/lib/eventhandler/federationhandler.py
@@ -39,7 +39,7 @@ from flask import current_app
 log = logging.getLogger(__name__)
 
 
-class ACTION_TYPE(object):
+class ACTION_TYPE:
     """
     Allowed actions
     """

--- a/edumfa/lib/eventhandler/logginghandler.py
+++ b/edumfa/lib/eventhandler/logginghandler.py
@@ -38,7 +38,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class LOGGING_LEVEL(object):
+class LOGGING_LEVEL:
     """
     Allowed logging levels
     """

--- a/edumfa/lib/eventhandler/requestmangler.py
+++ b/edumfa/lib/eventhandler/requestmangler.py
@@ -47,7 +47,7 @@ from dateutil.tz import tzlocal
 log = logging.getLogger(__name__)
 
 
-class ACTION_TYPE(object):
+class ACTION_TYPE:
     """
     Allowed actions
     """

--- a/edumfa/lib/eventhandler/responsemangler.py
+++ b/edumfa/lib/eventhandler/responsemangler.py
@@ -38,7 +38,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class ACTION_TYPE(object):
+class ACTION_TYPE:
     """
     Allowed actions
     """

--- a/edumfa/lib/eventhandler/tokenhandler.py
+++ b/edumfa/lib/eventhandler/tokenhandler.py
@@ -60,7 +60,7 @@ from dateutil.tz import tzlocal
 log = logging.getLogger(__name__)
 
 
-class ACTION_TYPE(object):
+class ACTION_TYPE:
     """
     Allowed actions
     """
@@ -83,13 +83,13 @@ class ACTION_TYPE(object):
     REMOVE_TOKENGROUP = "remove tokengroup"
     ATTACH_APPLICATION = "attach application"
 
-class TOKEN_APPLICATIONS(object):
+class TOKEN_APPLICATIONS:
     SSH = "ssh"
     OFFLINE = "offline"
     LUKS = "luks"
 
 
-class VALIDITY(object):
+class VALIDITY:
     """
     Allowed validity options
     """

--- a/edumfa/lib/eventhandler/usernotification.py
+++ b/edumfa/lib/eventhandler/usernotification.py
@@ -64,7 +64,7 @@ To check your tokens you may login to the Web UI:
 """
 
 
-class NOTIFY_TYPE(object):
+class NOTIFY_TYPE:
     """
     Allowed token owner
     """

--- a/edumfa/lib/eventhandler/webhookeventhandler.py
+++ b/edumfa/lib/eventhandler/webhookeventhandler.py
@@ -38,7 +38,7 @@ log = logging.getLogger(__name__)
 TIMEOUT = 10
 
 
-class CONTENT_TYPE(object):
+class CONTENT_TYPE:
     """
     Allowed type off content
     """
@@ -46,7 +46,7 @@ class CONTENT_TYPE(object):
     URLENCODED = "urlendcode"
 
 
-class ACTION_TYPE(object):
+class ACTION_TYPE:
     """
     Allowed actions
     """

--- a/edumfa/lib/importotp.py
+++ b/edumfa/lib/importotp.py
@@ -581,7 +581,7 @@ def parsePSKCdata(xml_data,
     return tokens, not_imported_serials
 
 
-class GPGImport(object):
+class GPGImport:
     """
     This class is used to decrypt GPG encrypted import files.
 

--- a/edumfa/lib/log.py
+++ b/edumfa/lib/log.py
@@ -82,7 +82,7 @@ class SecureFormatter(Formatter):
         return s
 
 
-class log_with(object):
+class log_with:
     """
     Logging decorator that allows you to log with a
     specific logger.

--- a/edumfa/lib/machines/base.py
+++ b/edumfa/lib/machines/base.py
@@ -30,7 +30,7 @@ This file is tested in tests/test_lib_machines.py
 import netaddr
 
 
-class Machine(object):
+class Machine:
 
     """
     The Machine object is returned by the resolver for a given machine_id.
@@ -100,7 +100,7 @@ class MachineResolverError(Exception):
     pass
 
 
-class BaseMachineResolver(object):
+class BaseMachineResolver:
 
     type = "base"
 

--- a/edumfa/lib/monitoringmodules/base.py
+++ b/edumfa/lib/monitoringmodules/base.py
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 from edumfa.lib.log import log_with
 
 
-class Monitoring(object):
+class Monitoring:
 
     def __init__(self, config=None):
         pass

--- a/edumfa/lib/pinhandling/base.py
+++ b/edumfa/lib/pinhandling/base.py
@@ -34,7 +34,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class PinHandler(object):
+class PinHandler:
     """
     A PinHandler Class is responsible for handling the OTP PIN during
     enrollment.

--- a/edumfa/lib/policy.py
+++ b/edumfa/lib/policy.py
@@ -129,7 +129,7 @@ DEFAULT_IOS_APP_URL = "https://apps.apple.com/us/app/privacyidea-authenticator/i
 DEFAULT_PREFERRED_CLIENT_MODE_LIST = ['interactive', 'webauthn', 'poll', 'u2f']
 
 
-class SCOPE(object):
+class SCOPE:
     __doc__ = """This is the list of the allowed scopes that can be used in
     policy definitions.
     """
@@ -143,7 +143,7 @@ class SCOPE(object):
     REGISTER = "register"
 
 
-class ACTION(object):
+class ACTION:
     __doc__ = """This is the list of usual actions."""
     ADMIN_DASHBOARD = "admin_dashboard"
     ASSIGN = "assign"
@@ -318,18 +318,18 @@ class ACTION(object):
     REQUIRE_DESCRIPTION = "require_description"
 
 
-class TYPE(object):
+class TYPE:
     INT = "int"
     STRING = "str"
     BOOL = "bool"
 
 
-class AUTHORIZED(object):
+class AUTHORIZED:
     ALLOW = "grant_access"
     DENY = "deny_access"
 
 
-class GROUP(object):
+class GROUP:
     __doc__ = """These are the allowed policy action groups. The policies
     will be grouped in the UI."""
     TOOLS = "tools"
@@ -347,7 +347,7 @@ class GROUP(object):
     SERVICEID = "service ID"
 
 
-class MAIN_MENU(object):
+class MAIN_MENU:
     __doc__ = """These are the allowed top level menu items. These are used
     to toggle the visibility of the menu items depending on the rights of the
     user"""
@@ -359,21 +359,21 @@ class MAIN_MENU(object):
     COMPONENTS = "components"
 
 
-class LOGINMODE(object):
+class LOGINMODE:
     __doc__ = """This is the list of possible values for the login mode."""
     USERSTORE = "userstore"
     EDUMFA = "eduMFA"
     DISABLE = "disable"
 
 
-class REMOTE_USER(object):
+class REMOTE_USER:
     __doc__ = """The list of possible values for the remote_user policy."""
     DISABLE = "disable"
     ACTIVE = "allowed"
     FORCE = "force"
 
 
-class ACTIONVALUE(object):
+class ACTIONVALUE:
     __doc__ = """This is a list of usual action values for e.g. policy
     action-values like otppin."""
     TOKENPIN = "tokenpin"
@@ -382,19 +382,19 @@ class ACTIONVALUE(object):
     NONE = "none"
 
 
-class AUTOASSIGNVALUE(object):
+class AUTOASSIGNVALUE:
     __doc__ = """This is the possible values for autoassign"""
     USERSTORE = "userstore"
     NONE = "any_pin"
 
 
-class TIMEOUT_ACTION(object):
+class TIMEOUT_ACTION:
     __doc__ = """This is a list of actions values for idle users"""
     LOGOUT = "logout"
     LOCKSCREEN = 'lockscreen'
 
 
-class CONDITION_SECTION(object):
+class CONDITION_SECTION:
     __doc__ = """This is a list of available sections for conditions of policies """
     USERINFO = "userinfo"
     TOKENINFO = "tokeninfo"
@@ -403,14 +403,14 @@ class CONDITION_SECTION(object):
     HTTP_ENVIRONMENT = "HTTP Environment"
 
 
-class CONDITION_CHECK(object):
+class CONDITION_CHECK:
     __doc__ = """The available check methods for extended conditions"""
     DO_NOT_CHECK_AT_ALL = 1
     ONLY_CHECK_USERINFO = [CONDITION_SECTION.USERINFO]
     CHECK_AND_RAISE_EXCEPTION_ON_MISSING = None
 
 
-class PolicyClass(object):
+class PolicyClass:
     """
     A policy object can be used to query the current set of policies.
     The policy object itself does not store any policies.
@@ -2619,7 +2619,7 @@ class MatchingError(ServerError):
     pass
 
 
-class Match(object):
+class Match:
     """
     This class provides a high-level API for policy matching.
 

--- a/edumfa/lib/policydecorators.py
+++ b/edumfa/lib/policydecorators.py
@@ -42,7 +42,7 @@ from edumfa.lib.radiusserver import get_radius
 log = logging.getLogger(__name__)
 
 
-class libpolicy(object):
+class libpolicy:
     """
     This is the decorator wrapper to call a specific function before a
     library call in contrast to prepolicy and postpolicy, which are to be

--- a/edumfa/lib/pooling.py
+++ b/edumfa/lib/pooling.py
@@ -39,7 +39,7 @@ from edumfa.lib.framework import get_app_local_store, get_app_config_value
 log = logging.getLogger(__name__)
 
 
-class BaseEngineRegistry(object):
+class BaseEngineRegistry:
     """
     Abstract base class for engine registries.
     """

--- a/edumfa/lib/queue.py
+++ b/edumfa/lib/queue.py
@@ -35,7 +35,7 @@ JOB_QUEUE_CLASS = "EDUMFA_JOB_QUEUE_CLASS"
 JOB_QUEUE_OPTION_PREFIX = "EDUMFA_JOB_QUEUE_"
 
 
-class JobCollector(object):
+class JobCollector:
     """
     For most third-party job queue modules, the jobs are discovered by tracking all
     functions decorated with a ``@job`` decorator. However, in order

--- a/edumfa/lib/queues/base.py
+++ b/edumfa/lib/queues/base.py
@@ -26,7 +26,7 @@ class QueueError(Exception):
     pass
 
 
-class BaseQueue(object):
+class BaseQueue:
     """
     A queue object represents an external job queue and is configured with
     a dictionary of options.

--- a/edumfa/lib/radiusserver.py
+++ b/edumfa/lib/radiusserver.py
@@ -47,7 +47,7 @@ This module is tested in tests/test_lib_radiusserver.py
 log = logging.getLogger(__name__)
 
 
-class RADIUSServer(object):
+class RADIUSServer:
     """
     RADIUS Server object with configuration. The RADIUS Server object
     contains a test functionality so that the configuration can be tested.

--- a/edumfa/lib/resolvers/LDAPIdResolver.py
+++ b/edumfa/lib/resolvers/LDAPIdResolver.py
@@ -260,7 +260,7 @@ def cache(func):
     return cache_wrapper
 
 
-class AUTHTYPE(object):
+class AUTHTYPE:
     SIMPLE = "Simple"
     SASL_DIGEST_MD5 = "SASL Digest-MD5"
     NTLM = "NTLM"

--- a/edumfa/lib/resolvers/UserIdResolver.py
+++ b/edumfa/lib/resolvers/UserIdResolver.py
@@ -41,7 +41,7 @@ Defines the rough interface for a UserId Resolver
 """
 
 
-class UserIdResolver(object):
+class UserIdResolver:
 
     fields = {"username": 1, "userid": 1,
               "description": 0,

--- a/edumfa/lib/security/default.py
+++ b/edumfa/lib/security/default.py
@@ -70,7 +70,7 @@ def int_list_to_bytestring(int_list):  # pragma: no cover
     return b"".join([bytes((i, )) for i in int_list])
 
 
-class SecurityModule(object):
+class SecurityModule:
     TOKEN_KEY = 0
     CONFIG_KEY = 1
     VALUE_KEY = 2

--- a/edumfa/lib/smsprovider/SMSProvider.py
+++ b/edumfa/lib/smsprovider/SMSProvider.py
@@ -69,7 +69,7 @@ class SMSError(Exception):
         return ret
 
 
-class ISMSProvider(object):
+class ISMSProvider:
     """ the SMS Provider Interface - BaseClass """
 
     regexp_description = _("Regular expression to modify the phone number to make it compatible with provider. "

--- a/edumfa/lib/smtpserver.py
+++ b/edumfa/lib/smtpserver.py
@@ -49,7 +49,7 @@ TIMEOUT = 10
 SEND_EMAIL_JOB_NAME = "smtpserver.send_email"
 
 
-class SMTPServer(object):
+class SMTPServer:
     """
     SMTP Object that holds a SMTP Database Object but can also send emails.
     """

--- a/edumfa/lib/subscriptions.py
+++ b/edumfa/lib/subscriptions.py
@@ -168,7 +168,7 @@ def check_signature(subscription):
     return True
 
 
-class CheckSubscription(object):
+class CheckSubscription:
     """
     Decorator to decorate an API request and check if the subscription is valid.
     For this, we evaluate the requesting client.

--- a/edumfa/lib/task/base.py
+++ b/edumfa/lib/task/base.py
@@ -27,7 +27,7 @@ can be given a set of options.
 """
 
 
-class BaseTask(object):
+class BaseTask:
     """
     A BaseTask returns a list of supported options.
     """

--- a/edumfa/lib/tokenclass.py
+++ b/edumfa/lib/tokenclass.py
@@ -94,24 +94,24 @@ TWOSTEP_DEFAULT_DIFFICULTY = 10000
 log = logging.getLogger(__name__)
 
 
-class CHALLENGE_SESSION(object):
+class CHALLENGE_SESSION:
     ENROLLMENT = "enrollment"
 
 
-class TOKENKIND(object):
+class TOKENKIND:
     SOFTWARE = "software"
     HARDWARE = "hardware"
     VIRTUAL = "virtual"
 
 
-class AUTHENTICATIONMODE(object):
+class AUTHENTICATIONMODE:
     AUTHENTICATE = 'authenticate'
     CHALLENGE = 'challenge'
     # If the challenge is answered out of band
     OUTOFBAND = 'outofband'
 
 
-class CLIENTMODE(object):
+class CLIENTMODE:
     """
     This informs eduMFA clients how to
     handle challenge-responses
@@ -122,7 +122,7 @@ class CLIENTMODE(object):
     WEBAUTHN = 'webauthn'
 
     
-class ROLLOUTSTATE(object):
+class ROLLOUTSTATE:
     CLIENTWAIT = 'clientwait'
     # The rollout is pending in the backend, like CSRs that need to be approved
     PENDING = 'pending'
@@ -134,7 +134,7 @@ class ROLLOUTSTATE(object):
     DENIED = 'denied'
 
 
-class TokenClass(object):
+class TokenClass:
 
     # Class properties
     using_pin = True

--- a/edumfa/lib/tokens/HMAC.py
+++ b/edumfa/lib/tokens/HMAC.py
@@ -48,7 +48,7 @@ from edumfa.lib.crypto import safe_compare
 log = logging.getLogger(__name__)
 
 
-class HmacOtp(object):
+class HmacOtp:
 
     def __init__(self, secObj=None, counter=0, digits=6, hashfunc=sha1):
         self.secretObj = secObj

--- a/edumfa/lib/tokens/certificatetoken.py
+++ b/edumfa/lib/tokens/certificatetoken.py
@@ -65,7 +65,7 @@ class ACTION(BASE_ACTION):
     CERTIFICATE_REQUEST_SUBJECT_COMPONENT = "certificate_request_subject_component"
 
 
-class REQUIRE_ACTIONS(object):
+class REQUIRE_ACTIONS:
     IGNORE = "ignore"
     VERIFY = "verify"
     REQUIRE_AND_VERIFY = "require_and_verify"

--- a/edumfa/lib/tokens/emailtoken.py
+++ b/edumfa/lib/tokens/emailtoken.py
@@ -77,7 +77,7 @@ log = logging.getLogger(__name__)
 TEST_SUCCESSFUL = "Successfully sent email. Please check your inbox."
 
 
-class EMAILACTION(object):
+class EMAILACTION:
     EMAILTEXT = "emailtext"
     EMAILSUBJECT = "emailsubject"
     EMAILAUTO = "emailautosend"

--- a/edumfa/lib/tokens/indexedsecrettoken.py
+++ b/edumfa/lib/tokens/indexedsecrettoken.py
@@ -53,7 +53,7 @@ DEFAULT_CHALLENGE_TEXT = _("Please enter the positions {0!s} from your secret.")
 DEFAULT_POSITION_COUNT = 2
 
 
-class PIIXACTION(object):
+class PIIXACTION:
     COUNT = "count"
     PRESET_ATTRIBUTE = "preset_attribute"
     FORCE_ATTRIBUTE = "force_attribute"

--- a/edumfa/lib/tokens/mOTP.py
+++ b/edumfa/lib/tokens/mOTP.py
@@ -47,7 +47,7 @@ from edumfa.lib.log import log_with
 log = logging.getLogger(__name__)
 
 
-class mTimeOtp(object):
+class mTimeOtp:
     '''
     implements the motp timebased check_otp
     - s. https://github.com/neush/otpn900/blob/master/src/test_motp.c

--- a/edumfa/lib/tokens/ocra.py
+++ b/edumfa/lib/tokens/ocra.py
@@ -44,7 +44,7 @@ SHA_FUNC = {"SHA1": sha1,
             "SHA512": sha512}
 
 
-class OCRASuite(object):
+class OCRASuite:
 
     def __init__(self, ocrasuite):
         """
@@ -199,7 +199,7 @@ class OCRASuite(object):
         return ret
 
 
-class OCRA(object):
+class OCRA:
 
     def __init__(self, ocrasuite, key=None, security_object=None):
         """

--- a/edumfa/lib/tokens/papertoken.py
+++ b/edumfa/lib/tokens/papertoken.py
@@ -38,7 +38,7 @@ log = logging.getLogger(__name__)
 DEFAULT_COUNT = 100
 
 
-class PAPERACTION(object):
+class PAPERACTION:
     PAPERTOKEN_COUNT = "papertoken_count"
 
 

--- a/edumfa/lib/tokens/passwordtoken.py
+++ b/edumfa/lib/tokens/passwordtoken.py
@@ -51,7 +51,7 @@ class PasswordTokenClass(TokenClass):
     default_length = DEFAULT_LENGTH
     default_contents = DEFAULT_CONTENTS
 
-    class SecretPassword(object):
+    class SecretPassword:
 
         def __init__(self, secObj):
             self.secretObject = secObj

--- a/edumfa/lib/tokens/pushtoken.py
+++ b/edumfa/lib/tokens/pushtoken.py
@@ -87,7 +87,7 @@ UPDATE_FB_TOKEN_WINDOW = 5
 POLL_ONLY = "poll only"
 
 
-class PUSH_ACTION(object):
+class PUSH_ACTION:
     FIREBASE_CONFIG = "push_firebase_configuration"
     REGISTRATION_URL = "push_registration_url"
     TTL = "push_ttl"
@@ -98,7 +98,7 @@ class PUSH_ACTION(object):
     ALLOW_POLLING = "push_allow_polling"
 
 
-class PushAllowPolling(object):
+class PushAllowPolling:
     ALLOW = 'allow'
     DENY = 'deny'
     TOKEN = 'token'  # nosec B105 # key name

--- a/edumfa/lib/tokens/questionnairetoken.py
+++ b/edumfa/lib/tokens/questionnairetoken.py
@@ -48,7 +48,7 @@ required = False
 DEFAULT_NUM_ANSWERS = 5
 
 
-class QUESTACTION(object):
+class QUESTACTION:
     NUM_QUESTIONS = "number"
 
 

--- a/edumfa/lib/tokens/smstoken.py
+++ b/edumfa/lib/tokens/smstoken.py
@@ -66,7 +66,7 @@ keylen = {'sha1': 20,
           'sha512': 64}
 
 
-class SMSACTION(object):
+class SMSACTION:
     SMSTEXT = "smstext"
     SMSPOSTCHECKTEXT = "smspostchecktext"
     SMSAUTO = "smsautosend"

--- a/edumfa/lib/tokens/tantoken.py
+++ b/edumfa/lib/tokens/tantoken.py
@@ -38,7 +38,7 @@ DEFAULT_COUNT = 100
 SALT_LENGTH = 4
 
 
-class TANACTION(object):
+class TANACTION:
     TANTOKEN_COUNT = "tantoken_count"
 
 

--- a/edumfa/lib/tokens/tiqrtoken.py
+++ b/edumfa/lib/tokens/tiqrtoken.py
@@ -109,7 +109,7 @@ required = False
 OCRA_DEFAULT_SUITE = "OCRA-1:HOTP-SHA1-6:QN10"
 
 
-class API_ACTIONS(object):
+class API_ACTIONS:
     METADATA = "metadata"
     ENROLLMENT = "enrollment"
     AUTHENTICATION = "authentication"

--- a/edumfa/lib/tokens/u2ftoken.py
+++ b/edumfa/lib/tokens/u2ftoken.py
@@ -194,7 +194,7 @@ optional = True
 required = False
 
 
-class U2FACTION(object):
+class U2FACTION:
     FACETS = "u2f_facets"
     REQ = "u2f_req"
     NO_VERIFY_CERT = "u2f_no_verify_certificate"

--- a/edumfa/lib/tokens/webauthn.py
+++ b/edumfa/lib/tokens/webauthn.py
@@ -95,7 +95,7 @@ DEFAULT_AUTHENTICATOR_EXTENSIONS = {"credProtect": None}
 log = logging.getLogger(__name__)
 
 
-class COSE_PUBLIC_KEY(object):
+class COSE_PUBLIC_KEY:
     """
     The indices of the various parameters in a COSE-formatted public key.
     """
@@ -107,7 +107,7 @@ class COSE_PUBLIC_KEY(object):
     N = -1
 
 
-class ATTESTATION_TYPE(object):
+class ATTESTATION_TYPE:
     """
     Attestation types known to this implementation.
     """
@@ -127,7 +127,7 @@ SUPPORTED_ATTESTATION_TYPES = (
 )
 
 
-class ATTESTATION_FORMAT(object):
+class ATTESTATION_FORMAT:
     """
     Attestation format identifiers as registered in the IANA WebAuthn attestation statement format identifiers registry.
     """
@@ -161,7 +161,7 @@ REGISTERED_ATTESTATION_FORMATS = (
 )
 
 
-class CLIENT_DATA_TYPE(object):
+class CLIENT_DATA_TYPE:
     """
     Client data types used by this implementation.
     """
@@ -176,7 +176,7 @@ SUPPORTED_CLIENT_DATA_TYPES = (
 )
 
 
-class COSE_ALGORITHM(object):
+class COSE_ALGORITHM:
     """
     IANA-assigned identifiers of supported COSE algorithms.
     """
@@ -194,7 +194,7 @@ SUPPORTED_COSE_ALGORITHMS = (
 )
 
 
-class ATTESTATION_FORM(object):
+class ATTESTATION_FORM:
     """
     The different forms of attestation.
     """
@@ -211,7 +211,7 @@ ATTESTATION_FORMS = (
 )
 
 
-class USER_VERIFICATION_LEVEL(object):
+class USER_VERIFICATION_LEVEL:
     """
     The different levels of user verification.
     """
@@ -228,7 +228,7 @@ USER_VERIFICATION_LEVELS = (
 )
 
 
-class ATTESTATION_LEVEL(object):
+class ATTESTATION_LEVEL:
     """
     The different levels of attestation requirement.
     """
@@ -268,7 +268,7 @@ ATTESTATION_REQUIREMENT_LEVELS = (
 )
 
 
-class AUTHENTICATOR_ATTACHMENT_TYPE(object):
+class AUTHENTICATOR_ATTACHMENT_TYPE:
     """
     The different types of authenticator attachment.
     """
@@ -283,7 +283,7 @@ AUTHENTICATOR_ATTACHMENT_TYPES = (
 )
 
 
-class TRANSPORT(object):
+class TRANSPORT:
     """
     The standard transports.
     """
@@ -301,7 +301,7 @@ TRANSPORTS = (
     TRANSPORT.INTERNAL,
 )
 
-class RESIDENT_KEY_LEVEL(object):
+class RESIDENT_KEY_LEVEL:
     """
     The different resident key levels
     """
@@ -315,7 +315,7 @@ RESIDENT_KEY_LEVELS = (
     RESIDENT_KEY_LEVEL.PREFERRED
 )
 
-class USERNAMELESS_AUTHN(object):
+class USERNAMELESS_AUTHN:
     """
     Whether to allow username-less authentication.
     """
@@ -327,7 +327,7 @@ USERNAMELESS_AUTHNS = (
     USERNAMELESS_AUTHN.DISABLED
 )
 
-class USERNAMELESS_REALM_POLICY(object):
+class USERNAMELESS_REALM_POLICY:
     """
     Whether to enable realm-specific policies in username-less authentication scenarios.
     """
@@ -371,7 +371,7 @@ class WebAuthnUserDataMissing(Exception):
     pass
 
 
-class AuthenticatorDataFlags(object):
+class AuthenticatorDataFlags:
     """
     Authenticator data flags:
 
@@ -432,7 +432,7 @@ class AuthenticatorDataFlags(object):
         return (self.flags & self.EXTENSION_DATA_INCLUDED) == self.EXTENSION_DATA_INCLUDED
 
 
-class WebAuthnMakeCredentialOptions(object):
+class WebAuthnMakeCredentialOptions:
     """
     Generate the options passed to navigator.credentials.create()
     """
@@ -604,7 +604,7 @@ class WebAuthnMakeCredentialOptions(object):
         return json.dumps(self.registration_dict)
 
 
-class WebAuthnAssertionOptions(object):
+class WebAuthnAssertionOptions:
     """
     Generate the options passed to navigator.credentials.get()
     """
@@ -725,7 +725,7 @@ class WebAuthnAssertionOptions(object):
         return json.dumps(self.assertion_dict)
 
 
-class WebAuthnUser(object):
+class WebAuthnUser:
     """
     A single WebAuthn user credential.
     """
@@ -783,7 +783,7 @@ class WebAuthnUser(object):
                                           self.user_display_name, self.sign_count)
 
 
-class WebAuthnCredential(object):
+class WebAuthnCredential:
     """
     A single WebAuthn credential.
     """
@@ -856,7 +856,7 @@ class WebAuthnCredential(object):
                                           self.origin, self.sign_count)
 
 
-class WebAuthnRegistrationResponse(object):
+class WebAuthnRegistrationResponse:
     """
     The WebAuthn registration response containing all information needed to verify the registration ceremony.
     """
@@ -1597,7 +1597,7 @@ class WebAuthnRegistrationResponse(object):
             raise RegistrationRejectedException('Registration rejected. Error: {}'.format(e))
 
 
-class WebAuthnAssertionResponse(object):
+class WebAuthnAssertionResponse:
     """
     The WebAuthn assertion response containing all information needed to verify the authentication ceremony.
     """

--- a/edumfa/lib/tokens/webauthntoken.py
+++ b/edumfa/lib/tokens/webauthntoken.py
@@ -494,7 +494,7 @@ optional = True
 required = False
 
 
-class WEBAUTHNCONFIG(object):
+class WEBAUTHNCONFIG:
     """
     Config options defined for WebAuthn
     """
@@ -510,7 +510,7 @@ WEBAUTHN_TOKEN_SPECIFIC_SETTINGS = {
 }
 
 
-class WEBAUTHNACTION(object):
+class WEBAUTHNACTION:
     """
     Policy actions defined for WebAuthn
     """
@@ -533,7 +533,7 @@ class WEBAUTHNACTION(object):
     AVOID_DOUBLE_REGISTRATION = 'webauthn_avoid_double_registration'
 
 
-class WEBAUTHNINFO(object):
+class WEBAUTHNINFO:
     """
     Token info fields used by WebAuthn
     """
@@ -550,7 +550,7 @@ class WEBAUTHNINFO(object):
     RESIDENT_KEY = "resident_key"
 
 
-class WEBAUTHNGROUP(object):
+class WEBAUTHNGROUP:
     """
     Categories used to group WebAuthn token actions.
     """

--- a/edumfa/lib/user.py
+++ b/edumfa/lib/user.py
@@ -55,7 +55,7 @@ from edumfa.models import CustomUserAttribute, db
 log = logging.getLogger(__name__)
 
 
-class User(object):
+class User:
     """
     The user has the attributes
       login, realm and resolver.

--- a/edumfa/lib/usercache.py
+++ b/edumfa/lib/usercache.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 EXPIRATION_SECONDS = "UserCacheExpiration"
 
 
-class user_cache(object):
+class user_cache:
     """
     This is the decorator wrapper to call a specific resolver function to
     allow user caching.

--- a/edumfa/lib/utils/compare.py
+++ b/edumfa/lib/utils/compare.py
@@ -152,7 +152,7 @@ def negate(func):
 #: This class enumerates all available comparators.
 #: In order to add a comparator to this module, add a suitable member to COMPARATORS
 #: and suitable entries to COMPARATOR_FUNCTIONS and COMPARATOR_DESCRIPTIONS.
-class COMPARATORS(object):
+class COMPARATORS:
     EQUALS = "equals"
     NOT_EQUALS = "!equals"
 

--- a/edumfa/models.py
+++ b/edumfa/models.py
@@ -80,7 +80,7 @@ def increment_by_zero(element, compiler, **kw):  # pragma: no cover
     return text
 
 
-class MethodsMixin(object):
+class MethodsMixin:
     """
     This class mixes in some common Class table functions like
     delete and save
@@ -122,7 +122,7 @@ def save_config_timestamp(invalidate_config=True):
         invalidate_config_object()
 
 
-class TimestampMethodsMixin(object):
+class TimestampMethodsMixin:
     """
     This class mixes in the table functions including update of the timestamp
     """

--- a/tests/base.py
+++ b/tests/base.py
@@ -19,7 +19,7 @@ PWFILE = "tests/testdata/passwords"
 PWFILE2 = "tests/testdata/passwd"
 
 
-class FakeFlaskG(object):
+class FakeFlaskG:
     policy_object = None
     logged_in_user = {}
     audit_object = None

--- a/tests/ldap3mock.py
+++ b/tests/ldap3mock.py
@@ -76,11 +76,11 @@ class CallList(Sequence, Sized):
         self._calls = []
 
 
-class Connection(object):
+class Connection:
 
-    class Extend(object):
+    class Extend:
 
-        class Standard(object):
+        class Standard:
 
             def __init__(self, connection):
                 self.connection = connection
@@ -638,7 +638,7 @@ class Connection(object):
         return True
 
 
-class Ldap3Mock(object):
+class Ldap3Mock:
 
     def __init__(self):
         self._calls = CallList()

--- a/tests/mscamock.py
+++ b/tests/mscamock.py
@@ -22,39 +22,39 @@
 #
 
 
-class MyTemplateReply(object):
+class MyTemplateReply:
     def __init__(self, templates):
         self.templateNames = templates
 
 
-class MyCAReply(object):
+class MyCAReply:
     def __init__(self, ca_list=None):
         self.caNames = ca_list or []
 
 
-class MyCSRReply(object):
+class MyCSRReply:
     def __init__(self, disposition=0, request_id=None, message="CSR invalid"):
         self.disposition = disposition
         self.dispositionMessage = message
         self.requestId = request_id or 4711
 
 
-class MyCertReply(object):
+class MyCertReply:
     def __init__(self, certificate):
         self.cert = certificate
 
 
-class MyCSRStatusReply(object):
+class MyCSRStatusReply:
     def __init__(self, disposition):
         self.disposition = disposition
 
 
-class MyCertificateReply(object):
+class MyCertificateReply:
     def __init__(self, certificate):
         self.cert = certificate
 
 
-class CAServiceMock(object):
+class CAServiceMock:
 
     def __init__(self, config, mock_config=None):
         self.cas = mock_config.get("available_cas") or []

--- a/tests/pkcs11mock.py
+++ b/tests/pkcs11mock.py
@@ -71,7 +71,7 @@ def fake_decrypt(data):
     return [(c - 1) % 256 for c in data]
 
 
-class PKCS11Mock(object):
+class PKCS11Mock:
     """
     Mock helper to simulate a HSM. Usage::
 

--- a/tests/radiusmock.py
+++ b/tests/radiusmock.py
@@ -59,7 +59,7 @@ class CallList(Sequence, Sized):
         self._calls = []
 
 
-class RadiusMock(object):
+class RadiusMock:
 
     def __init__(self):
         self._calls = CallList()

--- a/tests/redismock.py
+++ b/tests/redismock.py
@@ -53,7 +53,7 @@ class CallList(Sequence, Sized):
         self._calls = []
 
 
-class Redis(object):
+class Redis:
 
     def __init__(self):
         self.dictionary = {}
@@ -69,7 +69,7 @@ class Redis(object):
         self.dictionary = data
 
 
-class RedisMock(object):
+class RedisMock:
 
     def __init__(self):
         self._calls = CallList()

--- a/tests/smppmock.py
+++ b/tests/smppmock.py
@@ -56,7 +56,7 @@ class CallList(Sequence, Sized):
         self._calls = []
 
 
-class SmppMock(object):
+class SmppMock:
 
     def __init__(self):
         self._calls = CallList()

--- a/tests/smtpmock.py
+++ b/tests/smtpmock.py
@@ -84,7 +84,7 @@ class CallList(Sequence, Sized):
     def reset(self):
         self._calls = []
 
-class SmtpMock(object):
+class SmtpMock:
 
     def __init__(self):
         self._calls = CallList()

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -2018,7 +2018,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
 
     def test_24b_push_disable_wait_policy(self):
         # We send a fake push_wait that is not in the policies
-        class RequestMock(object):
+        class RequestMock:
             pass
         req = RequestMock()
         req.all_data = {"push_wait": "120"}
@@ -2131,7 +2131,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         delete_policy("Indexed")
 
     def test_26a_webauthn_auth_validate_triggerchallenge(self):
-        class RequestMock(object):
+        class RequestMock:
             pass
 
         # Normal request
@@ -2194,7 +2194,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         )
 
     def test_26b_webauthn_auth_validate_check(self):
-        class RequestMock(object):
+        class RequestMock:
             pass
         # Normal request
         request = RequestMock()
@@ -2262,7 +2262,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         )
 
     def test_26c_webauthn_auth_auth(self):
-        class RequestMock(object):
+        class RequestMock:
             pass
 
         # Normal request
@@ -2305,7 +2305,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         )
 
     def test_27a_webauthn_authz_validate_check(self):
-        class RequestMock(object):
+        class RequestMock:
             pass
 
         # Normal request
@@ -2418,7 +2418,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         )
 
     def test_28_webauthn_enroll(self):
-        class RequestMock(object):
+        class RequestMock:
             pass
 
         rp_id = RP_ID
@@ -2754,7 +2754,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         )
 
     def test_29c_webauthn_request_auth_authn(self):
-        class RequestMock(object):
+        class RequestMock:
             pass
 
         # Normal request
@@ -2859,7 +2859,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         )
 
     def test_29e_webauthn_request_validate_check_authn(self):
-        class RequestMock(object):
+        class RequestMock:
             pass
 
         # Normal request
@@ -3002,7 +3002,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         )
 
     def test_31_webauthn_disallowed_req(self):
-        class RequestMock(object):
+        class RequestMock:
             pass
 
         allowed_certs = "subject/.*Frobnicate.*/"
@@ -3030,7 +3030,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         )
 
     def test_32_webauthn_allowed_aaguid(self):
-        class RequestMock(object):
+        class RequestMock:
             pass
 
         request = RequestMock()
@@ -3043,7 +3043,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         self.assertTrue(webauthntoken_allowed(request, None))
 
     def test_33_webauthn_disallowed_aaguid(self):
-        class RequestMock(object):
+        class RequestMock:
             pass
 
         authenticator_selection_list = 'foo bar baz'

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -1205,7 +1205,7 @@ class PolicyTestCase(MyTestCase):
                                ("userinfo", "groups", "contains", "b", True)])
         P = PolicyClass()
 
-        class MockUser(object):
+        class MockUser:
             login = 'login'
             realm = 'realm'
             resolver = 'resolver'
@@ -1268,7 +1268,7 @@ class PolicyTestCase(MyTestCase):
     def test_30_filter_by_conditions_errors(self):
         P = PolicyClass()
 
-        class MockUser(object):
+        class MockUser:
             login = 'login'
             realm = 'realm'
             resolver = 'resolver'
@@ -1383,7 +1383,7 @@ class PolicyTestCase(MyTestCase):
 
         P = PolicyClass()
 
-        class MockUser(object):
+        class MockUser:
             login = 'login'
             realm = 'realm'
             resolver = 'resolver'
@@ -1426,7 +1426,7 @@ class PolicyTestCase(MyTestCase):
 
         P = PolicyClass()
 
-        class MockUser(object):
+        class MockUser:
             login = 'login'
             realm = 'realm'
             resolver = 'resolver'
@@ -1478,7 +1478,7 @@ class PolicyTestCase(MyTestCase):
 
     def test_33_get_allowed_attributes(self):
 
-        class MockUser(object):
+        class MockUser:
             login = 'login'
             realm = 'realm'
             resolver = 'resolver'

--- a/tests/test_lib_queue.py
+++ b/tests/test_lib_queue.py
@@ -16,7 +16,7 @@ from edumfa.lib.queues.base import QueueError
 from .base import OverrideConfigTestCase, MyTestCase
 
 
-class TestSender(object):
+class TestSender:
     """ defined in order to be able to mock the ``send_mail`` function in tests """
     def send_mail(*args, **kwargs):
         pass

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -1606,7 +1606,7 @@ class TokenTestCase(MyTestCase):
 
     def test_59_weigh_token_types(self):
 
-        class dummy_token(object):
+        class dummy_token:
             def __init__(self, type):
                 self.type = type
         self.assertEqual(1000, weigh_token_type(dummy_token("push")))

--- a/tools/edumfa-migrate-linotp.py
+++ b/tools/edumfa-migrate-linotp.py
@@ -99,7 +99,7 @@ UUID_MATCH_PATTERN = "^([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA
 UUID_REPLACE_PATTERN = "\\4\\3\\2\\1-\\6\\5-\\8\\7-\\9\\10-\\11\\12\\13\\14\\15\\16"
 
 
-class Config(object):
+class Config:
 
     def __init__(self, config_file):
         with open(config_file, "r") as f:

--- a/tools/edumfa-sync-owncloud.py
+++ b/tools/edumfa-sync-owncloud.py
@@ -31,7 +31,7 @@ EXAMPLE_CONFIG_FILE = """{
 }"""
 
 
-class Config(object):
+class Config:
 
     def __init__(self, config_file):
         with open(config_file, "r") as f:


### PR DESCRIPTION
Inhering from `object` was never required in Python 3.

I have done no further testing of this change.
