### PR TITLE
Fix migration for apache and nginx packages

### DIFF
--- a/deploy/ubuntu-server/edumfa-apache2.postinst
+++ b/deploy/ubuntu-server/edumfa-apache2.postinst
@@ -17,7 +17,7 @@ CERTDAYS=1095
 CERTKEYSIZE=4096
 MIGRATIONSDIR=/opt/edumfa/lib/edumfa/migrations/
 MYSQLFIX=/etc/mysql/conf.d/edumfa-maxkeylengthfix.cnf
-DB_CREATED=0
+DB_CREATED=false
 
 if test -f /etc/default/edumfa; then
   . /etc/default/edumfa
@@ -109,7 +109,7 @@ create_database() {
     echo "SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://edumfa:$NPW@localhost/edumfa?charset=utf8'" >> /etc/edumfa/edumfa.cfg
     echo "DB created"
     /opt/edumfa/bin/edumfa-manage create_tables || true
-    DB_CREATED=1
+    DB_CREATED=true
   fi
 }
 
@@ -162,7 +162,7 @@ case "$1" in
     create_certificate
     #update-rc.d apache2 defaults
     service apache2 restart
-    if [ "$DB_CREATED" ]; then
+    if [ "$DB_CREATED" = true ]; then
       # We've created the DB, so we stamp the DB
       touch /tmp/edumfa-install
       /opt/edumfa/bin/edumfa-manage db stamp -d $MIGRATIONSDIR head

--- a/deploy/ubuntu-server/edumfa-nginx.postinst
+++ b/deploy/ubuntu-server/edumfa-nginx.postinst
@@ -16,7 +16,7 @@ CERTDAYS=1095
 CERTKEYSIZE=4096
 MIGRATIONSDIR=/opt/edumfa/lib/edumfa/migrations/
 MYSQLFIX=/etc/mysql/conf.d/edumfa-maxkeylengthfix.cnf
-DB_CREATED=0
+DB_CREATED=false
 
 
 if test -f /etc/default/edumfa; then
@@ -110,7 +110,7 @@ create_database() {
     echo "SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://edumfa:$NPW@localhost/edumfa?charset=utf8'" >> /etc/edumfa/edumfa.cfg
     echo "DB created"
     /opt/edumfa/bin/edumfa-manage create_tables || true
-    DB_CREATED=1
+    DB_CREATED=true
   fi
 }
 
@@ -146,7 +146,7 @@ case "$1" in
     create_database
     enable_nginx_uwsgi
     create_certificate
-    if [ "$DB_CREATED" ]; then
+    if [ "$DB_CREATED" = true ]; then
       # We've created the DB, so we stamp the DB
       /opt/edumfa/bin/edumfa-manage db stamp -d $MIGRATIONSDIR head
     else


### PR DESCRIPTION
Currently the Apache2 and Nginx .deb packages only properly work for a fresh install of edumfa. When updating the packages and database migration steps are required (e.g. privacyidea -> edumfa) the database currently just get stamped, which breaks edumfa's database migration.

This pull requests fixes that and migration steps are executed automatically when updating the package or migration to eduMFA.