### PR TITLE
fix: print logo to stderr

### DIFF
--- a/edumfa/commands/manage/main.py
+++ b/edumfa/commands/manage/main.py
@@ -57,7 +57,7 @@ def cli():
       / _ \/ _` | | | | |\/| |  __/ /\ \  
      |  __/ (_| | |_| | |  | | | / ____ \ 
       \___|\__,_|\__,_|_|  |_|_|/_/    \_\ {0!s:>12}
-    """.format('v{0!s}'.format(get_version_number())))
+    """.format('v{0!s}'.format(get_version_number())), err=True)
 
 
 cli.add_command(audit_cli)


### PR DESCRIPTION
stdout should be preserved for well formated output that can be properly
processed by other tools.
This simplifies using the output of edumfa-manage in e.g. Ansible.

This was also the behaviour of privacyIDEA.