### PR TITLE
feat: handle passkey AuthenticatorDataFlags 

### DIFF
--- a/edumfa/lib/tokens/webauthn.py
+++ b/edumfa/lib/tokens/webauthn.py
@@ -380,6 +380,8 @@ class AuthenticatorDataFlags:
 
     USER_PRESENT = 1 << 0
     USER_VERIFIED = 1 << 2
+    BACKUP_ELIGIBILITY = 1 << 3
+    BACKUP_STATE = 1 << 4
     ATTESTATION_DATA_INCLUDED = 1 << 6
     EXTENSION_DATA_INCLUDED = 1 << 7
 
@@ -412,6 +414,24 @@ class AuthenticatorDataFlags:
         """
 
         return (self.flags & self.USER_VERIFIED) == self.USER_VERIFIED
+
+    @property
+    def backup_eligible(self):
+        """
+        :return: Whether the public key credential source is backup eligible.
+        :rtype: bool
+        """
+
+        return (self.flags & self.BACKUP_STATE) == self.BACKUP_STATE
+
+    @property
+    def backed_up(self):
+        """
+        :return: Whether the public key credential source is currently backed up.
+        :rtype: bool
+        """
+
+        return (self.flags & self.BACKUP_ELIGIBILITY) == self.BACKUP_ELIGIBILITY
 
     @property
     def attestation_data_included(self):

--- a/edumfa/lib/tokens/webauthn.py
+++ b/edumfa/lib/tokens/webauthn.py
@@ -422,7 +422,7 @@ class AuthenticatorDataFlags:
         :rtype: bool
         """
 
-        return (self.flags & self.BACKUP_STATE) == self.BACKUP_STATE
+        return (self.flags & self.BACKUP_ELIGIBILITY) == self.BACKUP_ELIGIBILITY
 
     @property
     def backed_up(self):
@@ -431,7 +431,7 @@ class AuthenticatorDataFlags:
         :rtype: bool
         """
 
-        return (self.flags & self.BACKUP_ELIGIBILITY) == self.BACKUP_ELIGIBILITY
+        return (self.flags & self.BACKUP_STATE) == self.BACKUP_STATE
 
     @property
     def attestation_data_included(self):

--- a/edumfa/lib/tokens/webauthntoken.py
+++ b/edumfa/lib/tokens/webauthntoken.py
@@ -632,7 +632,7 @@ class WebAuthnTokenClass(TokenClass):
                     },
                     WEBAUTHNACTION.TIMEOUT: {
                         'type': 'int',
-                        'desc': _("The time in seconds the user has to confirm authorization on his WebAuthn token. " 
+                        'desc': _("The time in seconds the user has to confirm authorization on his WebAuthn token. "
                                   "Note: You will want to increase the ChallengeValidityTime along with this. "
                                   "Default: 60"),
                         'group': WEBAUTHNGROUP.WEBAUTHN
@@ -650,22 +650,20 @@ class WebAuthnTokenClass(TokenClass):
                     },
                     WEBAUTHNACTION.USERNAMELESS_AUTHN: {
                         'type': 'bool',
-                        'desc': _("Enable username-less authentication, also known as Conditional UI, Conditional "
-                                  "Mediation, or Browser Autofill UI? "
-                                  "Note: This function only works if resident keys are enrolled as WebAuthn tokens and "
-                                  "if the browsers support this feature. "
-                                  "Also, the WebAuthn authentication policies 'challenge_text', 'allowed_transports', "
-                                  "and 'timeout' will be ignored. Policies for the RP_ID and UV can only be enforced "
-                                  "for a whole realm with the option below."),
+                        'desc': _("Whether usernameless authentication via the Passkeys Autofill UI, also known as "
+                                  "Conditional Mediation, should be enabled. "
+                                  "Note: This function is only available if passkeys (resident keys) are enrolled and "
+                                  "if the browser supports Conditional Mediation. "
+                                  "Other WebAuthn authentication policies will be ignored if this option is enabled. "),
                         'group': WEBAUTHNGROUP.WEBAUTHN
                     },
                     WEBAUTHNACTION.USERNAMELESS_REALM_POLICY: {
                         'type': 'bool',
-                        'desc': _("Enable the WebAuthn authentication policies for Relying Party ID and User "
-                                  "Verification Requirement realm-wide, i.e for all users in a realm? "
-                                  "Note: This requires username-less authentication to be enabled. The client has to "
-                                  "send its realm via a query parameter in the calls to /validate/triggerchallenge and "
-                                  "/validate/check, e.g. /validate/triggerchallenge?type=webauthn&realm=foo"),
+                        'desc': _("Whether to enforce the WebAuthn authentication policies for the relying party ID "
+                                  "and the user verification requirement realm-wide, i.e., for all users in a realm? "
+                                  "Note: This requires usernameless authentication to be enabled. Also, the option "
+                                  "has to be set in the fudiscr plugin so the realm is sent to the API endpoints via a "
+                                  "query parameter, e.g., /validate/triggerchallenge?type=webauthn&realm=userless"),
                         'group': WEBAUTHNGROUP.WEBAUTHN
                     }
                 },
@@ -775,7 +773,7 @@ class WebAuthnTokenClass(TokenClass):
                     },
                     WEBAUTHNACTION.AUTHENTICATOR_RESIDENT_KEY: {
                         'type': 'str',
-                        'desc': _("Whether a resident key shall be requested or not"),
+                        'desc': _("Whether to request a resident key. Note: Passkeys are always resident keys."),
                         'group': WEBAUTHNGROUP.WEBAUTHN,
                         'value': [
                             "discouraged",
@@ -1002,7 +1000,7 @@ class WebAuthnTokenClass(TokenClass):
                         self.add_tokeninfo(WEBAUTHNINFO.RESIDENT_KEY, "Not enough info")
                 except Exception as e:
                     log.warning('Could not parse registrationClientExtensions: {0!s}'.format(e))
-                    
+
             # If no description has already been set, set the automatic description or the
             # description given in the 2nd request
             if not self.token.description:


### PR DESCRIPTION
This PR adds support for WebAuthn Level 3 AuthenticatorDataFlags, see [spec](https://www.w3.org/TR/webauthn-3/#sctn-authenticator-data)
This allows us to set additional information for a WebAuthn credentials:
- whether it can be backed up/synced
- whether it is already backed up/synced
- whether it is a passkey/resident key/discoverable credential