### PR TITLE
fix: output totp algorithm uppercase

### DIFF
--- a/edumfa/lib/apps.py
+++ b/edumfa/lib/apps.py
@@ -140,7 +140,7 @@ def create_google_authenticator_url(key=None, user=None,
     url_issuer = quote(issuer.encode("utf-8"))
 
     if hash_algo.lower() != "sha1":
-        hash_algo = "algorithm={0!s}&".format(hash_algo)
+        hash_algo = "algorithm={0!s}&".format(hash_algo.upper())
     else:
         # If the hash_algo is SHA1, we do not add it to the QR code to keep
         # the QR code simpler

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -2183,7 +2183,7 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(result.get("value"))
             detail = res.json.get("detail")
             googleurl = detail.get("googleurl")
-            self.assertTrue("sha256" in googleurl.get("value"))
+            self.assertTrue("SHA256" in googleurl.get("value"))
             serial = detail.get("serial")
             token = get_tokens(serial=serial)[0]
             self.assertEqual(token.hashlib, "sha256")


### PR DESCRIPTION
otpauth link contains lowercase hash keyword which cant be read by Google Authenticator and therefore google authenticator generates wrong totps

further description in #234 