### PR TITLE
feat: change import filename arguments to type click.File

### DIFF
--- a/edumfa/commands/manage/audit.py
+++ b/edumfa/commands/manage/audit.py
@@ -56,7 +56,7 @@ def dump(filename, timelimit=None):
 @click.option('-lw', '--lowwatermark', type=int, default=5000, show_default=True,
               help="Keep this number of entries.")
 @click.option('--age', help="Delete audit entries older than these number of days.")
-@click.option('--config', help="Read config from the specified yaml file.")
+@click.option('--config', type=click.File('r'), help="Read config from the specified yaml file.")
 @click.option('--dryrun', is_flag=True, help="Do not actually delete, only show what would be done.")
 @click.option('--chunksize', type=int, help="Delete entries in chunks of the given size to avoid deadlocks")
 def rotate_audit(highwatermark, lowwatermark, age=0, config=None, dryrun=False, chunksize=None):
@@ -106,8 +106,7 @@ def rotate_audit(highwatermark, lowwatermark, age=0, config=None, dryrun=False, 
     # create a Session
     metadata.create_all(engine)
     if config:
-        with open(config, 'r') as f:
-            yml_config = yaml.safe_load(f)
+        yml_config = yaml.safe_load(config)
         auditlogs = session.query(LogEntry).all()
         delete_list = []
         for log in auditlogs:

--- a/edumfa/commands/manage/config.py
+++ b/edumfa/commands/manage/config.py
@@ -150,11 +150,13 @@ def import_full_config(file, cleanup, update, purge):
                 tar.extractall(members=tarinfo_objects)
                 tar.close()
                 for tarinfo in tarinfo_objects:
-                    data = conf_import(filename=tarinfo.name)
+                    with open(tarinfo.name) as f:
+                        data = conf_import(file=f)
                     # cleanup extracted files
                     os.remove(tarinfo.name)
             else:
-                data = conf_import(filename=file)
+                with open(file) as f:
+                    data = conf_import(file=f)
     else:
         data = conf_import()
     import_conf_event(data["event"], cleanup=cleanup, update=update, purge=purge)

--- a/edumfa/commands/manage/config.py
+++ b/edumfa/commands/manage/config.py
@@ -186,7 +186,8 @@ def export_full_config(passwords, archive, directory):
         config_backup_file_base = f"{directory}/{BASE_NAME}-{HOSTNAME}-{DATE}"
         config_backup_file = f"{config_backup_file_base}.py"
 
-        conf_export(data, filename=config_backup_file)
+        with open(config_backup_file) as f:
+            conf_export(data, f)
         if archive:
             config_backup_archive = f"{config_backup_file_base}.tar.gz"
             tar = tarfile.open(config_backup_archive, "w:gz")
@@ -196,4 +197,4 @@ def export_full_config(passwords, archive, directory):
             if tarfile.is_tarfile(config_backup_archive):
                 os.remove(config_backup_file)
     else:
-        conf_export(data, filename=None)
+        conf_export(data, sys.stdout)

--- a/edumfa/commands/manage/event.py
+++ b/edumfa/commands/manage/event.py
@@ -78,14 +78,14 @@ def delete(eid):
 
 
 @export_cli.command("event")
-@click.option("-f", "filename", help="filename to export")
+@click.option("-f", "filename", type=click.File('w'), default=sys.stdout, help="filename to export")
 @click.option("-n", "name", help="event to export")
 def e_export(filename, name):
     """
     Export the specified event or all events to a file.
     If the filename is omitted, the event configurations are written to stdout.
     """
-    conf_export({"event": get_conf_event(name)}, filename=filename)
+    conf_export({"event": get_conf_event(name)}, filename)
 
 
 @import_cli.command("event")

--- a/edumfa/commands/manage/event.py
+++ b/edumfa/commands/manage/event.py
@@ -89,7 +89,7 @@ def e_export(filename, name):
 
 
 @import_cli.command("event")
-@click.option("-f", "filename", help="filename to import", required=True)
+@click.option("-f", "filename", help="filename to import", required=True, type=click.File('r'))
 @click.option("-c", "cleanup", help="cleanup configuration before import", is_flag=True)
 @click.option("-u", "update", help="update configuration during import", is_flag=True)
 @click.option(
@@ -105,7 +105,7 @@ def e_import(filename, cleanup, update, purge):
     If 'cleanup' is specified the existing events are deleted before the
     events from the file are imported.
     """
-    data = conf_import(conftype="event", filename=filename)
+    data = conf_import(conftype="event", file=filename)
     import_conf_event(data["event"], cleanup=cleanup, update=update, purge=purge)
 
 

--- a/edumfa/commands/manage/helper.py
+++ b/edumfa/commands/manage/helper.py
@@ -56,7 +56,7 @@ def conf_import(file=None, conftype=None):
     return contents_var
 
 
-def conf_export(config, filename=None):
+def conf_export(config, file):
     """
     Export configurations to a file or write them to stdout if no filename is given.
     """
@@ -64,11 +64,7 @@ def conf_export(config, filename=None):
     pp = pprint.PrettyPrinter(indent=4)
 
     ret_str = pp.pformat(config)
-    if filename:
-        with open(filename, 'w') as f:
-            f.write(ret_str)
-    if not filename:
-        print(ret_str)
+    file.write(ret_str)
 
 
 def get_conf_policy(name=None):

--- a/edumfa/commands/manage/helper.py
+++ b/edumfa/commands/manage/helper.py
@@ -29,16 +29,14 @@ from edumfa.lib.resolver import get_resolver_list, save_resolver
 DEFAULT_CONFTYPE_LIST = ("policy", "resolver", "event")
 
 
-def conf_import(filename=None, conftype=None):
+def conf_import(file=None, conftype=None):
     """
     import eduMFA configuration from file
     """
-    if filename:
-        with open(filename, 'r') as f:
-            contents = f.read()
-    else:
-        filename = "Standard input"
-        contents = sys.stdin.read()
+    if file is None:
+        file = sys.stdin
+
+    contents = file.read()
 
     contents_var = ast.literal_eval(contents)
 
@@ -54,7 +52,7 @@ def conf_import(filename=None, conftype=None):
             conftype_list = list(contents_var.keys())
 
     for conftype in conftype_list:
-        click.echo("Importing {0!s} from {1!s}".format(conftype, filename))
+        click.echo("Importing {0!s} from {1!s}".format(conftype, file.name))
     return contents_var
 
 

--- a/edumfa/commands/manage/policy.py
+++ b/edumfa/commands/manage/policy.py
@@ -74,14 +74,14 @@ def delete(name):
 
 
 @export_cli.command("policy")
-@click.option("-f", "filename", help="filename to export")
+@click.option("-f", "filename", type=click.File('w'), default=sys.stdout, help="filename to export")
 @click.option("-n", "name", help="policy to export")
 def p_export(filename, name):
     """
     Export the specified policy or all policies to a file.
     If the filename is omitted, the policies are written to stdout.
     """
-    conf_export({"policy": get_conf_policy(name)}, filename=filename)
+    conf_export({"policy": get_conf_policy(name)}, filename)
 
 
 @import_cli.command("policy")

--- a/edumfa/commands/manage/policy.py
+++ b/edumfa/commands/manage/policy.py
@@ -85,7 +85,7 @@ def p_export(filename, name):
 
 
 @import_cli.command("policy")
-@click.option("-f", "filename", help="filename to import", required=True)
+@click.option("-f", "filename", help="filename to import", required=True, type=click.File('r'))
 @click.option("-c", "cleanup", help="cleanup configuration before import", is_flag=True)
 @click.option("-u", "update", help="update configuration during import", is_flag=True)
 @click.option(
@@ -101,7 +101,7 @@ def p_import(filename, cleanup, update, purge):
     If 'cleanup' is specified the existing policies are deleted before the
     policies from the file are imported.
     """
-    data = conf_import(conftype="policy", filename=filename)
+    data = conf_import(conftype="policy", file=filename)
     import_conf_policy(data["policy"], cleanup=cleanup, update=update, purge=purge)
 
 

--- a/edumfa/commands/manage/resolver.py
+++ b/edumfa/commands/manage/resolver.py
@@ -136,7 +136,7 @@ def create_internal(name):
 
 
 @export_cli.command("resolver")
-@click.option("-f", "filename", help="filename to export")
+@click.option("-f", "filename", type=click.File('w'), default=sys.stdout, help="filename to export")
 @click.option("-n", "name", help="resolver to export")
 @click.option("-p", "--print_passwords", "print_passwords", is_flag=True,
               help="Print the passwords used in the resolver configuration. "
@@ -148,7 +148,7 @@ def r_export(filename, name, print_passwords):
     This behavior may be changed by 'print_passwords'.
     If the filename is omitted, the resolvers are written to stdout.
     """
-    conf_export({"resolver": get_conf_resolver(name, print_passwords)}, filename=filename)
+    conf_export({"resolver": get_conf_resolver(name, print_passwords)}, filename)
 
 
 @import_cli.command("resolver")

--- a/edumfa/commands/manage/resolver.py
+++ b/edumfa/commands/manage/resolver.py
@@ -152,7 +152,7 @@ def r_export(filename, name, print_passwords):
 
 
 @import_cli.command("resolver")
-@click.option("-f", "filename", help="filename to import", required=True)
+@click.option("-f", "filename", help="filename to import", required=True, type=click.File('r'))
 @click.option("-c", "cleanup", help="cleanup configuration before import", is_flag=True)
 @click.option("-u", "update", help="update configuration during import", is_flag=True)
 @click.option(
@@ -169,7 +169,7 @@ def r_import(filename, cleanup, update, purge):
     Values given as __CENSORED__ (like e.g. passwords) are not touched during the update.
     """
     # Todo: Support the cleanup option to remove all resolvers which do not exist in the imported file
-    data = conf_import(conftype="resolver", filename=filename)
+    data = conf_import(conftype="resolver", file=filename)
     import_conf_resolver(data["resolver"], cleanup=cleanup, update=update, purge=purge)
 
 


### PR DESCRIPTION
All command line flags with the same name should have the same behavior for consistency’s sake.
Using `click.File` gives us the option to read from `stdin` for free when the user specifies `-`.

The same could be done for other flags.