### PR TITLE
docs: document eduPUSH type and deprecate Push Token Type

### DIFF
--- a/doc/configuration/sms_gateway_config.rst
+++ b/doc/configuration/sms_gateway_config.rst
@@ -29,11 +29,11 @@ via the Google Firebase service and this is used for :ref:`edupush_token` and :r
 
 
 You can get the necessary *JSON config file*, from your Firebase console.
-The Push authenticator App (eduMFA Authenticator) which you can find in Google Play Store and
+The eduPUSH authenticator App (eduMFA Authenticator) which you can find in Google Play Store and
 Apple App Store uses a Firebase project, that is managed by the GWDG.
 You need to get in touch trough support@gwdg.de with them, to receive a JSON config file for accessing the project.
 
-When using the the legacy Push token type, please refer to the privacyIDEA documentation. However we don't recommend or support using it anymore.
+When using the the legacy PUSH token type, please refer to the privacyIDEA documentation. However we don't recommend or support using it anymore.
 
 
 HTTP provider

--- a/doc/configuration/sms_gateway_config.rst
+++ b/doc/configuration/sms_gateway_config.rst
@@ -19,7 +19,7 @@ Firebase Provider
 ~~~~~~~~~~~~~~~~~
 
 The Firebase provider sends notifications
-via the Google Firebase service and this is used for the :ref:`push_token`.
+via the Google Firebase service and this is used for :ref:`edupush_token` and :ref:`push_token`.
 
 **JSON config file**
 
@@ -29,10 +29,11 @@ via the Google Firebase service and this is used for the :ref:`push_token`.
 
 
 You can get the necessary *JSON config file*, from your Firebase console.
-The unsupported PUSH authenticator App (privacyIDEA Authenticator) which you can
-find in Google Play Store and Apple App Store uses a Firebase project, that is
-managed by the company NetKnights.
-You need to get an SLA to receive a JSON config file for accessing the project.
+The Push authenticator App (eduMFA Authenticator) which you can find in Google Play Store and
+Apple App Store uses a Firebase project, that is managed by the GWDG.
+You need to get in touch trough support@gwdg.de with them, to receive a JSON config file for accessing the project.
+
+When using the the legacy Push token type, please refer to the privacyIDEA documentation. However we don't recommend or support using it anymore.
 
 
 HTTP provider

--- a/doc/faq/time.rst
+++ b/doc/faq/time.rst
@@ -16,9 +16,9 @@ might not work at all.
 If the time of your system is drifting, TOTP tokens, that once worked could stop working if the time drift gets
 to big to quick.
 
-Push tokens use the time during enrollment, for synchronization and for the poll functionality.
-To avoid replay attacks the Push tokens send a timestamp during the poll request. If you system is off only by a few
-minutes, the poll mechanism of Push tokens will not work.
+PUSH tokens use the time during enrollment, for synchronization and for the poll functionality.
+To avoid replay attacks these tokens send a timestamp during the poll request. If you system is off only by a few
+minutes, the poll mechanism of these tokens will not work.
 
 System and Logs
 ~~~~~~~~~~~~~~~

--- a/doc/modules/lib/tokentypes/edupush.rst
+++ b/doc/modules/lib/tokentypes/edupush.rst
@@ -1,0 +1,8 @@
+.. _code_edupush_token:
+
+eduPUSH Token
+~~~~~~~~~~
+
+.. autoclass:: edumfa.lib.tokens.pushtoken.PushTokenClass
+   :members:
+   :undoc-members:

--- a/doc/modules/lib/tokentypes/push.rst
+++ b/doc/modules/lib/tokentypes/push.rst
@@ -1,8 +1,8 @@
 .. _code_push_token:
 
-Push Token
+Legacy PUSH Token
 ~~~~~~~~~~
 
-.. autoclass:: edumfa.lib.tokens.pushtoken.PushTokenClass
+.. autoclass:: edumfa.lib.tokens.legacypushtoken.LegacyPushTokenClass
    :members:
    :undoc-members:

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -374,7 +374,7 @@ type: string
 
 This policy allows the rollout of tokens during the authentication via `/validate/check`.
 
-The policy action can take one of the followig token types: `hotp`, `totp`, `push`, `email`, `sms`.
+The policy action can take one of the following token types: `hotp`, `totp`, `edupush`, `push`, `email`, `sms`.
 
 The clients and plugins should make use of this policy in a transparent way and using multiple consecutive
 challenges.
@@ -409,10 +409,10 @@ have to enter the OTP value sent via email or text message.
 
 **PUSH**
 
-After the fist successful authentication step the user is presented a QR code for push token
+After the fist successful authentication step the user is presented a QR code for PUSH
 enrollment. The user needs to scan the QR code with an Authenticator App.
 If the token is successfully enrolled, the user is logged in without any further interaction.
-Since the successful enrollment of the Push token already verifies the presence of the user's smartphone,
+Since the successful enrollment of the PUSH token already verifies the presence of the user's smartphone,
 there is no additional authentication step anymore during enrollment.
 
 .. note:: Enrolling multiple token types one after another is not supported. It is currently possible to
@@ -517,7 +517,7 @@ dependent on the clients IP address and the user agent.
 
 .. _policy_push_text_on_mobile:
 
-push_text_on_mobile
+edupush_text_on_mobile, push_text_on_mobile
 ~~~~~~~~~~~~~~~~~~~
 
 .. index:: push token, Firebase service
@@ -525,13 +525,13 @@ push_text_on_mobile
 type: string
 
 This is the text that should be displayed on the push notification
-during the login process with a :ref:`push_token`.
+during the login process with a :ref:`edupush_token` or :ref:`push_token`.
 You can choose different texts for different users or IP addresses.
 This way you could customize push notifications for different applications.
 
 .. _policy_push_title_on_mobile:
 
-push_title_on_mobile
+edupush_title_on_mobile, push_title_on_mobile
 ~~~~~~~~~~~~~~~~~~~~
 
 .. index:: push token, Firebase service
@@ -540,11 +540,11 @@ type: string
 
 This is the title of the push notification that is displayed
 on the user's smartphone during the login process with
-a :ref:`push_token`.
+a :ref:`edupush_token` or :ref:`push_token`.
 
 .. _policy_push_wait:
 
-push_wait
+edupush_wait, push_wait
 ~~~~~~~~~
 
 .. index:: push token, push direct authentication
@@ -552,11 +552,11 @@ push_wait
 type: int
 
 This can be set to a number of seconds. If this is set, the authentication
-with a push token is only performed via one request to ``/validate/check``.
+with a PUSH token is only performed via one request to ``/validate/check``.
 The HTTP request to ``/validate/check`` will wait up to this number of
-seconds and check, if the push challenge was confirmed by the user.
+seconds and check, if the PUSH challenge was confirmed by the user.
 
-This way push tokens can be used with any non-push-capable applications.
+This way PUSH tokens can be used with any non-push-capable applications.
 
 Sensible numbers might be 10 or 20 seconds.
 
@@ -572,26 +572,26 @@ Sensible numbers might be 10 or 20 seconds.
 
 .. _policy_auth_push_allow_poll:
 
-push_allow_polling
+edupush_allow_polling, push_allow_polling
 ~~~~~~~~~~~~~~~~~~
 
 .. index:: push token
 
 type: string
 
-This policy configures if push tokens are allowed to poll the server for open
-challenges (e.g. when the the third-party push service is unavailable or
+This policy configures if PUSH tokens are allowed to poll the server for open
+challenges (e.g. when the the third-party PUSH service is unavailable or
 unreliable).
 
 The following options are available:
 
 ``allow``
 
-    *Allow* push tokens to poll for challenges.
+    *Allow* PUSH tokens to poll for challenges.
 
 ``deny``
 
-    *Deny* push tokens to poll for challenges. This basically returns a ``403``
+    *Deny* PUSH tokens to poll for challenges. This basically returns a ``403``
     error when requesting the poll endpoint.
 
 ``token``
@@ -605,13 +605,13 @@ The default is to ``allow`` polling
 
 .. _policy_push_ssl_verify_auth:
 
-push_ssl_verify
+edupush_ssl_verify, push_ssl_verify
 ~~~~~~~~~~~~~~~
 
 type: int
 
 The smartphone needs to verify the SSL certificate of the eduMFA server during
-the authentication with push tokens. By default, the verification is enabled. To disable
+the authentication with PUSH tokens. By default, the verification is enabled. To disable
 verification during enrollment, see :ref:`policy_push_ssl_verify_enrollment`.
 
 .. _policy_challenge_text:

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -407,36 +407,36 @@ to force the user to protect the token with a PIN.
 
 .. _policy_firebase_config:
 
-push_firebase_configuration
+edupush_firebase_configuration, push_firebase_configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 type: string
 
-For enrolling a :ref:`push_token`, the administrator can select which
+For enrolling a :ref:`edupush_token` or :ref:`push_token`, the administrator can select which
 Firebase configuration should be used.
 The administrator can create several connections to the Firebase service
 (see :ref:`firebase_provider`).
 This way even different Firebase configurations could be
 used depending on the user's realm or the IP address.
 
-If the push token is supposed to run in poll-only mode,
+If the PUSH token is supposed to run in poll-only mode,
 then the entry "poll only" can be selected instead of a firebase configuration.
 In this mode, neither the eduMFA server nor the smartphone app will connect to Google
 Firebase during enrollment or authentication.
 Note, that you also need to set the authentication policy
 :ref:`policy_auth_push_allow_poll` to allow the push token to poll for challenges.
 
-push_registration_url
+edupush_registration_url, push_registration_url
 ~~~~~~~~~~~~~~~~~~~~~
 
 type: string
 
-This is the URL of your eduMFA server, which the push App should
+This is the URL of your eduMFA server, which the PUSH App should
 connect to for the second registration step.
-This URL usually ends with ``/ttype/push``. Note, that the smartphone app
+This URL usually ends with ``/ttype/edupush`` for eduPUSH and ``/ttype/push`` legacy PUSH. Note, that the smartphone app
 may connect to a different eduMFA URL than the URL of the eduMFA Web UI.
 
-push_ttl
+edupush_ttl, push_ttl
 ~~~~~~~~
 
 This is the time (in minutes) how long the eduMFA server
@@ -446,13 +446,13 @@ could take some time to happen.
 
 .. _policy_push_ssl_verify_enrollment:
 
-push_ssl_verify
+edupush_ssl_verify, push_ssl_verify
 ~~~~~~~~~~~~~~~
 
 type: int
 
 The smartphone needs to verify the SSL certificate of the eduMFA server during
-the enrollment of push tokens. By default, the verification is enabled. To disable
+the enrollment of PUSH tokens. By default, the verification is enabled. To disable
 verification during authentication, see :ref:`policy_push_ssl_verify_auth`.
 
 .. _policy_verify_enrollment:

--- a/doc/policies/webui.rst
+++ b/doc/policies/webui.rst
@@ -347,7 +347,7 @@ show_android_privacyidea_authenticator
 
 type: ``bool``
 
-If this policy is activated, the enrollment page for HOTP, TOTP and Push tokens
+If this policy is activated, the enrollment page for HOTP, TOTP and PUSH tokens
 will contain a QR code, that leads the user to the Google Play Store where he can
 directly install the unsupported privacyIDEA Authenticator App for Android devices.
 
@@ -356,7 +356,7 @@ show_ios_privacyidea_authenticator
 
 type: ``bool``
 
-If this policy is activated, the enrollment page for HOTP, TOTP and Push tokens
+If this policy is activated, the enrollment page for HOTP, TOTP and PUSH tokens
 will contain a QR code, that leads the user to the Apple App Store where he can
 directly install the unsupported privacyIDEA Authenticator App for iOS devices.
 

--- a/doc/tokens/authentication_modes.rst
+++ b/doc/tokens/authentication_modes.rst
@@ -53,7 +53,7 @@ Here are examples for the flows:
   The "client_mode" is either set to ``webauthn`` or ``u2f`` so that the plugin
   can handle the cryptographic challenge accordingly.
 * The PUSH and TiQR token types implement the ``outofband`` mode.
-  With a PUSH token, the authentication step also consists of two steps:
+  With PUSH tokens, the authentication step also consists of two steps:
   In a first step, the user triggers a challenge. eduMFA pushes the
   challenge to the user's smartphone app. In a second step, the user approves
   the challenge on their phone, and the app responds to the challenge by

--- a/doc/tokens/supported_tokens.rst
+++ b/doc/tokens/supported_tokens.rst
@@ -62,7 +62,7 @@ Smartphone Apps
 on the concept of the Google Authenticator and works with the usual QR Code key URI
 enrollment. But on top it also allows for a more secure
 enrollment process (See :ref:`2step_enrollment`).
-It can be used for :ref:`hotp_token`, :ref:`totp_token` and :ref:`push_token`.
+It can be used for :ref:`hotp_token`, :ref:`totp_token`, :ref:`edupush_token` and :ref:`push_token`.
 
 **Google Authenticator**. The Google Authenticator is working well in
 :ref:`hotp_token`

--- a/doc/tokens/tokentypes.rst
+++ b/doc/tokens/tokentypes.rst
@@ -28,7 +28,7 @@ Some token require prior configuration as described in :ref:`tokentypes_details`
 * :ref:`ocra_token` - A basic OATH Challenge Response token.
 * :ref:`paper_token` - event based One Time Password tokens that get
   you list of one time passwords on a sheet of paper.
-* :ref:`push_token` - A challenge response token, that sends a
+* :ref:`edupush_token` and :ref:`push_token` - A challenge response token, that sends a
   challenge to the user's smartphone and the user simply accepts the
   request to login.
 * :ref:`pw_token` - A password token used for :ref:`lost_token` scenario.

--- a/doc/tokens/tokentypes/edupush.rst
+++ b/doc/tokens/tokentypes/edupush.rst
@@ -1,21 +1,17 @@
-.. _push_token:
+.. _edupush_token:
 
-Push Token (Legacy)
+eduPush Token
 ----------
 
-.. index:: Push Token, Firebase service
+.. index:: eduPush Token, Firebase service
 
-The push token uses the *unsupported privacyIDEA Authenticator* app. You can get it
+The edupush token uses the *eduMFA Authenticator* app. You can get it
 from `Google Play Store`_ or `Apple App Store`_.
 
-.. _Google Play Store: https://play.google.com/store/apps/details?id=it.netknights.piauthenticator
-.. _Apple App Store: https://apps.apple.com/us/app/privacyidea-authenticator/id1445401301
+.. _Google Play Store: https://play.google.com/store/apps/details?id=io.edumfa.authenticator
+.. _Apple App Store: https://apps.apple.com/app/edumfa-authenticator/id6479982721
 
-.. warning::
-    The push token type is deprecated and will be removed in the future. We strongly recommend using the
-    :ref:`edupush_token` token type instead.
-
-The token type *push* sends a cryptographic challenge via the
+The token type *edupush* sends a cryptographic challenge via the
 Google Firebase service to the smartphone of the user. This push
 notification is displayed on the smartphone of the user with a text
 that tells the user that he or somebody else requests to login to a
@@ -42,13 +38,13 @@ Configuration
 The minimum necessary configuration is an ``enrollment`` policy
 :ref:`policy_firebase_config`.
 
-With the ``authentication`` policies :ref:`policy_push_text_on_mobile`
+With the ``authentication`` policies :ref:`policy_edupush_text_on_mobile`
 and :ref:`policy_push_title_on_mobile` you can define
 the contents of the push notification.
 
 If you want to use push tokens with legacy applications that are not yet set up to be compatible with out-of-band
-tokens, you can set the ``authentication`` policy :ref:`policy_push_wait`. Please note, that setting this policy can
-interfere with other tokentypes and will impact performance, as detailed in the documentation for ``push_wait``.
+tokens, you can set the ``authentication`` policy :ref:`policy_edupush_wait`. Please note, that setting this policy can
+interfere with other tokentypes and will impact performance, as detailed in the documentation for ``edupush_wait``.
 
 Enrollment
 ~~~~~~~~~~
@@ -59,7 +55,7 @@ Step 1
 ......
 
 The user scans a QR code. This QR code contains the
-basic information for the push token and a enrollment URL, to which
+basic information for the edupush token and a enrollment URL, to which
 the smartphone should respond in the enrollment process.
 
 The smartphone stores this data and creates a new key pair.

--- a/doc/tokens/tokentypes/edupush.rst
+++ b/doc/tokens/tokentypes/edupush.rst
@@ -1,11 +1,11 @@
 .. _edupush_token:
 
-eduPush Token
+eduPUSH Token
 ----------
 
 .. index:: eduPush Token, Firebase service
 
-The edupush token uses the *eduMFA Authenticator* app. You can get it
+The eduPUSH token uses the *eduMFA Authenticator* app. You can get it
 from `Google Play Store`_ or `Apple App Store`_.
 
 .. _Google Play Store: https://play.google.com/store/apps/details?id=io.edumfa.authenticator
@@ -20,17 +20,17 @@ The smartphone sends a cryptographically signed response to the
 eduMFA server and the login request gets marked as confirmed
 in the eduMFA server. The application checks for this mark and
 logs the user in automatically. For an example of how the components in a
-typical deployment of push tokens interact reference the following diagram.
+typical deployment of eduPUSH tokens interact reference the following diagram.
 
 .. figure:: images/tokentype_push.png
   :width: 500
 
-  *A typical push token deployment*
+  *A typical eduPUSH token deployment*
 
 To allow eduMFA to send push notifications, a Firebase service
 needs to be configured. To do so see :ref:`firebase_provider`.
 
-The PUSH token implements the :ref:`outofband mode <authentication_mode_outofband>`.
+The eduPUSH token implements the :ref:`outofband mode <authentication_mode_outofband>`.
 
 Configuration
 ~~~~~~~~~~~~~
@@ -38,24 +38,24 @@ Configuration
 The minimum necessary configuration is an ``enrollment`` policy
 :ref:`policy_firebase_config`.
 
-With the ``authentication`` policies :ref:`policy_edupush_text_on_mobile`
+With the ``authentication`` policies :ref:`policy_push_text_on_mobile`
 and :ref:`policy_push_title_on_mobile` you can define
 the contents of the push notification.
 
-If you want to use push tokens with legacy applications that are not yet set up to be compatible with out-of-band
-tokens, you can set the ``authentication`` policy :ref:`policy_edupush_wait`. Please note, that setting this policy can
-interfere with other tokentypes and will impact performance, as detailed in the documentation for ``edupush_wait``.
+If you want to use eduPUSH tokens with legacy applications that are not yet set up to be compatible with out-of-band
+tokens, you can set the ``authentication`` policy :ref:`policy_push_wait`. Please note, that setting this policy can
+interfere with other token types and will impact performance, as detailed in the documentation for ``edupush_wait``.
 
 Enrollment
 ~~~~~~~~~~
 
-The enrollment of the push token happens in two steps.
+The enrollment of the eduPUSH token happens in two steps.
 
 Step 1
 ......
 
 The user scans a QR code. This QR code contains the
-basic information for the edupush token and a enrollment URL, to which
+basic information for the eduPUSH token and a enrollment URL, to which
 the smartphone should respond in the enrollment process.
 
 The smartphone stores this data and creates a new key pair.

--- a/doc/tokens/tokentypes/push.rst
+++ b/doc/tokens/tokentypes/push.rst
@@ -1,18 +1,18 @@
 .. _push_token:
 
-Push Token (Legacy)
+Legacy PUSH Token
 ----------
 
 .. index:: Push Token, Firebase service
 
-The push token uses the *unsupported privacyIDEA Authenticator* app. You can get it
+The legacy PUSH token uses the *unsupported privacyIDEA Authenticator* app. You can get it
 from `Google Play Store`_ or `Apple App Store`_.
 
 .. _Google Play Store: https://play.google.com/store/apps/details?id=it.netknights.piauthenticator
 .. _Apple App Store: https://apps.apple.com/us/app/privacyidea-authenticator/id1445401301
 
 .. warning::
-    The push token type is deprecated and will be removed in the future. We strongly recommend using the
+    The legacy PUSH token type is deprecated and will be removed in the future. We strongly recommend using the
     :ref:`edupush_token` token type instead.
 
 The token type *push* sends a cryptographic challenge via the
@@ -24,17 +24,17 @@ The smartphone sends a cryptographically signed response to the
 eduMFA server and the login request gets marked as confirmed
 in the eduMFA server. The application checks for this mark and
 logs the user in automatically. For an example of how the components in a
-typical deployment of push tokens interact reference the following diagram.
+typical deployment of legacy PUSH tokens interact reference the following diagram.
 
 .. figure:: images/tokentype_push.png
   :width: 500
 
-  *A typical push token deployment*
+  *A typical legacy PUSH token deployment*
 
 To allow eduMFA to send push notifications, a Firebase service
 needs to be configured. To do so see :ref:`firebase_provider`.
 
-The PUSH token implements the :ref:`outofband mode <authentication_mode_outofband>`.
+The legacy PUSH token implements the :ref:`outofband mode <authentication_mode_outofband>`.
 
 Configuration
 ~~~~~~~~~~~~~
@@ -46,20 +46,20 @@ With the ``authentication`` policies :ref:`policy_push_text_on_mobile`
 and :ref:`policy_push_title_on_mobile` you can define
 the contents of the push notification.
 
-If you want to use push tokens with legacy applications that are not yet set up to be compatible with out-of-band
+If you want to use legacy PUSH tokens with legacy applications that are not yet set up to be compatible with out-of-band
 tokens, you can set the ``authentication`` policy :ref:`policy_push_wait`. Please note, that setting this policy can
 interfere with other tokentypes and will impact performance, as detailed in the documentation for ``push_wait``.
 
 Enrollment
 ~~~~~~~~~~
 
-The enrollment of the push token happens in two steps.
+The enrollment of the legacy PUSH token happens in two steps.
 
 Step 1
 ......
 
 The user scans a QR code. This QR code contains the
-basic information for the push token and a enrollment URL, to which
+basic information for the legacy PUSH token and a enrollment URL, to which
 the smartphone should respond in the enrollment process.
 
 The smartphone stores this data and creates a new key pair.


### PR DESCRIPTION
This pull request updates documentation regarding:
- EduPush Token Type
- Mark old push token type as legacy and provides deprecation note