### PR TITLE
fix: append webauthn policy information to `type=webauthn` triggerchallenges

### DIFF
--- a/edumfa/api/lib/prepolicy.py
+++ b/edumfa/api/lib/prepolicy.py
@@ -1922,7 +1922,7 @@ def webauthntoken_auth(request, action):
     # passive and will just pull values from policies and add them to properly
     # prefixed fields in the request data, this is not a problem.
 
-    if not request.all_data.get("type") \
+    if (not request.all_data.get("type") or request.all_data.get("type").lower() == WebAuthnTokenClass.get_class_type()) \
             and not is_webauthn_assertion_response(request.all_data) \
             and ('serial' not in request.all_data
                  or request.all_data['serial'].startswith(WebAuthnTokenClass.get_class_prefix())):


### PR DESCRIPTION
Right now the "not request.all_data.get("type")" checks breaks using type=webauthn with "ERR905: Missing parameter: 'webauthn_allowed_transports'"


The DFN AAI Wiki recommended setting an event policy for fudiscr as a workaround, this does break the API in an undocumented fashion (returning a string in the json object instead of an array), which at least can be partiall fixed by limiting the event to `type` `webauthn` instead of all triggerchallenges.

There is the comment
> dass aufgrund eines Features/Bugs in Verbindung mit der zuvor genannten Policy idp-application-tokentype der Parameter webauthn_allowed_transports per Event gesetzt werden muss. 

But I'm unsure how this can be classified as a feature or what the goal of the current behavior is?

Would be good if someone happens to know more and could shed some light on this, if there is a good reason not to change the behavior.