### PR TITLE
fix: add missing MULTIVALUEATTRIBUTES parameter to LDAPIdResolver

### DIFF
--- a/edumfa/lib/resolvers/LDAPIdResolver.py
+++ b/edumfa/lib/resolvers/LDAPIdResolver.py
@@ -1021,7 +1021,8 @@ class IdResolver (UserIdResolver):
                                 'SERVERPOOL_SKIP': 'int',
                                 'SERVERPOOL_PERSISTENT': 'bool',
                                 'OBJECT_CLASSES': 'string',
-                                'DN_TEMPLATE': 'string'}
+                                'DN_TEMPLATE': 'string',
+                                'MULTIVALUEATTRIBUTES': 'string'}
         return {typ: descriptor}
 
     @classmethod


### PR DESCRIPTION
When adding a ldapresolver with this parameter set, a warning is currently shown in console, plus and the entry added in resolverconfig is missing the type definition for the configuration entry.
This simple fix adds the missing definition of the field.