### PR TITLE
POC: webauthn registration split thingie

### DIFF
--- a/edumfa/api/token.py
+++ b/edumfa/api/token.py
@@ -163,6 +163,7 @@ def init():
     :jsonparam rollover: Set this to 1 or true to indicate, that you want to rollover a token.
                     This is mandatory to rollover tokens, that are in the clientwait state.
     :jsonparam info: string representation of a json object whose key-value pairs will be set as tokeninfo.
+    :jsonparam webauthn_tyoe: String representing a webauthn type (resident, non-resident)
 
     :return: a json result with a boolean "result": true
 

--- a/edumfa/lib/tokens/webauthntoken.py
+++ b/edumfa/lib/tokens/webauthntoken.py
@@ -94,6 +94,7 @@ it in two steps:
 
     type=webauthn
     user=<username>
+    webauthntype=<webauthnType>
 
 The request returns:
 
@@ -910,6 +911,7 @@ class WebAuthnTokenClass(TokenClass):
         elif reg_data and client_data and self.token.rollout_state == ROLLOUTSTATE.CLIENTWAIT:
             serial = self.token.serial
             registration_client_extensions = getParam(param, "registrationclientextensions", optional)
+            webauthn_requested_type = getParam(param, "webauthntype", optional)
 
             rp_id = getParam(param, WEBAUTHNACTION.RELYING_PARTY_ID, required)
             uv_req = getParam(param, WEBAUTHNACTION.USER_VERIFICATION_REQUIREMENT, optional)
@@ -1091,6 +1093,21 @@ class WebAuthnTokenClass(TokenClass):
                                  givenname=self.user.info.get("givenname", ""),
                                  surname=self.user.info.get("surname", ""))
 
+            webauthn_type=getParam(params, "webauthntype", optional)
+            resident_key=getParam(params,
+                                  WEBAUTHNACTION.AUTHENTICATOR_RESIDENT_KEY,
+                                  optional)
+            if webauthn_type == "resident":
+                if resident_key == "discouraged":
+                    raise ParameterError("resident key requested when AUTHENTICATOR_RESIDENT_KEY is set to discouraged.")
+                else:
+                    resident_key = "required"
+            elif webauthn_type == "non-resident":
+                if resident_key == "required":
+                    raise ParameterError("non-resident key requested when AUTHENTICATOR_RESIDENT_KEY is set to required.")
+                else:
+                    resident_key = "discouraged"
+
             public_key_credential_creation_options = WebAuthnMakeCredentialOptions(
                 challenge=webauthn_b64_encode(nonce),
                 rp_name=getParam(params,
@@ -1120,9 +1137,7 @@ class WebAuthnTokenClass(TokenClass):
                 authenticator_selection_list=getParam(params,
                                                       WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST,
                                                       optional),
-                resident_key=getParam(params,
-                                      WEBAUTHNACTION.AUTHENTICATOR_RESIDENT_KEY,
-                                      optional),
+                resident_key=resident_key,
                 credential_ids=credential_ids
             ).registration_dict
 

--- a/edumfa/static/components/token/views/token.enroll.webauthn.html
+++ b/edumfa/static/components/token/views/token.enroll.webauthn.html
@@ -3,3 +3,13 @@
     Alliance. You can register this token with any webservice and with
     as many web services you wish to.
 </p>
+<!-- ng-hide="checkRight('webauthn_user_select')-->
+<div class="form-group">
+    <fieldset>
+        <input type="radio" name="webauthntype" value="resident" id="resident" ng-model="form.webauthntype"/>
+	<label for="resident" translate>Passkey</label>
+
+        <input type="radio" name="webauthntype" value="non-resident" id="non-resident" ng-model="form.webauthntype"/>
+	<label for="non-resident" translate>Generic WebAuthn</label>
+    </fieldset>
+</div>


### PR DESCRIPTION
Just some quick POC I hacked together as a basis for discussion.

There seem to be two ways to get this going in an easy way
a) Expand the API to allow sending some kind of webauthn type on the first init call (done in this poc)
b) Do it purely in Frontend and Patch the returned WebAuthn Credential Options there

TODO:
- [ ] Policy to enable/disable the user facing token selection
- [ ] UI Dependent on `AUTHENTICATOR_RESIDENT_KEY` set to `preferred`
- [ ] Also Require User Presence for Passkey type? (Or is this already implicit by requiring a resident key?)
- [ ] Flesh out UI, some Description Text

Resolves #320 