### PR TITLE
chore: add support for python 3.13

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,7 +38,7 @@ jobs:
       # don't cancel running matrix tests when one test fails
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/edumfa/api/policy.py
+++ b/edumfa/api/policy.py
@@ -54,7 +54,6 @@ from ..api.lib.prepolicy import prepolicy, check_base_action
 
 from flask import g
 from werkzeug.datastructures import FileStorage
-from cgi import FieldStorage
 
 import logging
 
@@ -392,16 +391,7 @@ def import_policy_api(filename=None):
 
     """
     policy_file = request.files['file']
-    file_contents = ""
-    # In case of form post requests, it is a "instance" of FieldStorage
-    # i.e. the Filename is selected in the browser and the data is
-    # transferred
-    # in an iframe. see: http://jquery.malsup.com/form/#sample4
-    #
-    if type(policy_file) == FieldStorage:  # pragma: no cover
-        log.debug("Field storage file: %s", policy_file)
-        file_contents = policy_file.value
-    elif type(policy_file) == FileStorage:
+    if type(policy_file) == FileStorage:
         log.debug("Werkzeug File storage file: %s", policy_file)
         file_contents = policy_file.read()
     else:  # pragma: no cover

--- a/edumfa/api/token.py
+++ b/edumfa/api/token.py
@@ -48,7 +48,6 @@ from ..lib.token import (init_token, get_tokens_paginate, assign_token,
                          delete_tokeninfo, import_token,
                          assign_tokengroup, unassign_tokengroup, set_tokengroups)
 from werkzeug.datastructures import FileStorage
-from cgi import FieldStorage
 from edumfa.lib.error import (ParameterError, TokenAdminError)
 from edumfa.lib.importotp import (parseOATHcsv, parseSafeNetXML,
                                        parseYubicoCSV, parsePSKCdata, GPGImport)
@@ -955,16 +954,7 @@ def loadtokens_api(filename=None):
     not_imported_serials = []
     TOKENS = {}
     token_file = request.files['file']
-    file_contents = ""
-    # In case of form post requests, it is a "instance" of FieldStorage
-    # i.e. the Filename is selected in the browser and the data is
-    # transferred
-    # in an iframe. see: http://jquery.malsup.com/form/#sample4
-    #
-    if type(token_file) == FieldStorage:  # pragma: no cover
-        log.debug("Field storage file: %s", token_file)
-        file_contents = token_file.value
-    elif type(token_file) == FileStorage:
+    if type(token_file) == FileStorage:
         log.debug("Werkzeug File storage file: %s", token_file)
         file_contents = token_file.read()
     else:  # pragma: no cover

--- a/edumfa/lib/resolvers/PasswdIdResolver.py
+++ b/edumfa/lib/resolvers/PasswdIdResolver.py
@@ -37,11 +37,17 @@
 import re
 import os
 import logging
-import crypt
+import sys
 import codecs
 
 from edumfa.lib.utils import to_bytes, convert_column_to_unicode
 from .UserIdResolver import UserIdResolver
+
+# Python 3.13 dropped crypt package, so we need to import crypt_r
+if sys.version_info >= (3, 13):
+    import crypt_r as crypt
+else:
+    import crypt
 
 log = logging.getLogger(__name__)
 ENCODING = "utf-8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12"
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dynamic = ["dependencies"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,8 @@ cryptography==43.0.1
     # via
     #   edumfa (setup.py)
     #   pyopenssl
+crypt-r==3.13.1; python_version == "3.13" and sys_platform == "linux"
+    # via edumfa (setup.py)
 defusedxml==0.7.1
     # via edumfa (setup.py)
 flask==3.0.3

--- a/tools/edumfa-create-pwidresolver-user
+++ b/tools/edumfa-create-pwidresolver-user
@@ -19,8 +19,12 @@
 import sys
 from getopt import getopt, GetoptError
 import getpass
-import crypt
-import random
+
+# Python 3.13 dropped crypt package, so we need to import crypt_r
+if sys.version_info >= (3, 13):
+    import crypt_r as crypt
+else:
+    import crypt
 
 __version__ = '0.1'
 

--- a/tools/edumfa-create-sqlidresolver-user
+++ b/tools/edumfa-create-sqlidresolver-user
@@ -21,8 +21,13 @@
 import sys
 from getopt import getopt, GetoptError
 import getpass
-import crypt
 import random
+
+# Python 3.13 dropped crypt package, so we need to import crypt_r
+if sys.version_info >= (3, 13):
+    import crypt_r as crypt
+else:
+    import crypt
 
 __version__ = '0.1'
 


### PR DESCRIPTION
This PR adds support for Python 3.13. This includes tests, classifiers and breaking changes.

## Breaking changes
### Removal of `cgi` module
The `cgi` (Common Gateway Interface) module has been removed with 3.13. This has been used in the policy import and load endpoints. Specifically the `FieldStorage` class was used, from which data was read. It seems like Flask doesn't use this module anymore, so the code has been removed.
### Removal of `crypt` module
The `crypt` module has also been removed with 3.13. it is used mainly in the `PasswdIdResolver.py` (`IdResolver.checkPass`) to verify the encrypted password. It is also used in 2 scripts to encrypt passwords: `edumfa-create-pwidresolver-user`, `edumfa-create-sqlidresolver-user`.
As a solution, the library `crypt-r` was added, which is a fork form the old `crypt` module. When installing edumfa on Python 3.13 it is installed and imported instead from the standard lib.

## TODO
- [ ] Test policy import and load endpoint
- [ ] Consider possibilities to migrate the password resolver to passlib/bcrypt, to get completely rid of `crypt`