### PR TITLE
fix: for events without serial or tokenowner, log 'N/A', not all tokens

### DIFF
--- a/edumfa/lib/eventhandler/logginghandler.py
+++ b/edumfa/lib/eventhandler/logginghandler.py
@@ -147,9 +147,11 @@ class LoggingEventHandler(BaseEventHandler):
                 tokens = get_tokens(serial=serial)
                 if tokens:
                     tokentype = tokens[0].get_tokentype()
-            else:
-                token_objects = get_tokens(user=tokenowner)
+            elif tokenowner:
+                token_objects = get_tokens(user=tokenowner, active=True)
                 serial = ','.join([tok.get_serial() for tok in token_objects])
+            else:
+                serial = 'N/A'
 
             tags = create_tag_dict(logged_in_user=logged_in_user,
                                    request=request,


### PR DESCRIPTION
Previously serial was filled with all tokens of all users if we had no tokenowner or serial in the event
(which is common in triggerchallenge for userless passkeys/webauthn).
Also if tokenowner is available, we now include only active token serials (on failed validate/check event).