### PR TITLE
fix: stamp db before migration in docker

### DIFF
--- a/deploy/docker-setup.sh
+++ b/deploy/docker-setup.sh
@@ -17,6 +17,14 @@ fi
 # Create DB
 echo "Creating DB"
 edumfa-manage createdb
+
+# Check and stamp DB
+STAMP=$(edumfa-manage db current -d /usr/local/lib/edumfa/migrations 2>/dev/null)
+if [[ -z "${STAMP//Running online/}" ]]; then
+  edumfa-manage db stamp head -d /usr/local/lib/edumfa/migrations
+fi
+
+# Upgrading DB
 echo "Upgrading Database"
 edumfa-manage db upgrade -d /usr/local/lib/edumfa/migrations
 


### PR DESCRIPTION
### Description

I have got the same error with the docker container as issue #360. As far as i understand the docker-setup.sh script tries to upgrade the new database before it has been stamped. I don't know if this is meant to be like this and if there is a deeper error in the code but i changed the docker-setup.sh to check for the stamp of the database before upgrading and its working.