### PR TITLE
doc/installation/docker.rst: add healthcheck for Mariadb

### DIFF
--- a/doc/installation/docker.rst
+++ b/doc/installation/docker.rst
@@ -45,7 +45,6 @@ For production you should replace the passwords and secrets with your own values
 
 .. code-block:: yaml
 
-   version: '3'
    services:
      mariadb:
        image: docker.io/mariadb:lts-jammy

--- a/doc/installation/docker.rst
+++ b/doc/installation/docker.rst
@@ -47,36 +47,36 @@ For production you should replace the passwords and secrets with your own values
 
    version: '3'
    services:
-      mariadb:
-         image: docker.io/mariadb:lts-jammy
-         restart: always
-         volumes:
-            - maria-data:/var/lib/mysql:rw
-         environment:
-            - MARIADB_PORT_NUMBER=3306
-            - MARIADB_DATABASE=edumfa
-            - MARIADB_USER=edumfa
-            - MARIADB_PASSWORD=pass
-            - MARIADB_ROOT_PASSWORD=pass
-         healthcheck:
-           test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
-           start_period: 10s
-           interval: 10s
-           timeout: 5s
-           retries: 3
-      edumfa:
-         image: ghcr.io/edumfa/edumfa:latest
-         ports:
-            - "8000:8000"
-         volumes:
-            - edumfa-config:/etc/edumfa
-            - /path/to/edumfa.cfg:/etc/edumfa/edumfa.cfg
-         environment:
-            - EDUMFA_ADMIN_USER=admin
-            - EDUMFA_ADMIN_PASS=Passwort123
-         depends_on:
-            mariadb:
-               condition: service_healthy
+     mariadb:
+       image: docker.io/mariadb:lts-jammy
+       restart: always
+       volumes:
+         - maria-data:/var/lib/mysql:rw
+       environment:
+         - MARIADB_PORT_NUMBER=3306
+         - MARIADB_DATABASE=edumfa
+         - MARIADB_USER=edumfa
+         - MARIADB_PASSWORD=pass
+         - MARIADB_ROOT_PASSWORD=pass
+       healthcheck:
+         test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+         start_period: 10s
+         interval: 10s
+         timeout: 5s
+         retries: 3
+     edumfa:
+       image: ghcr.io/edumfa/edumfa:latest
+       ports:
+         - "8000:8000"
+       volumes:
+         - edumfa-config:/etc/edumfa
+         - /path/to/edumfa.cfg:/etc/edumfa/edumfa.cfg
+       environment:
+         - EDUMFA_ADMIN_USER=admin
+         - EDUMFA_ADMIN_PASS=Passwort123
+       depends_on:
+         mariadb:
+           condition: service_healthy
 
    volumes:
       edumfa-config:

--- a/doc/installation/docker.rst
+++ b/doc/installation/docker.rst
@@ -58,6 +58,12 @@ For production you should replace the passwords and secrets with your own values
             - MARIADB_USER=edumfa
             - MARIADB_PASSWORD=pass
             - MARIADB_ROOT_PASSWORD=pass
+         healthcheck:
+           test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+           start_period: 10s
+           interval: 10s
+           timeout: 5s
+           retries: 3
       edumfa:
          image: ghcr.io/edumfa/edumfa:latest
          ports:
@@ -69,7 +75,8 @@ For production you should replace the passwords and secrets with your own values
             - EDUMFA_ADMIN_USER=admin
             - EDUMFA_ADMIN_PASS=Passwort123
          depends_on:
-            - mariadb
+            mariadb:
+               condition: service_healthy
 
    volumes:
       edumfa-config:


### PR DESCRIPTION
Add a healthcheck for the MariaDB container and have the eduMFA container wait, until the MariaDB container is healthy. This prevents eduMFA failing to connect to the database, if it starts faster than MariaDB is fully up and running.

fix #473 