### PR TITLE
fix: use format string for last auth timestamp

### DIFF
--- a/edumfa/lib/policydecorators.py
+++ b/edumfa/lib/policydecorators.py
@@ -32,6 +32,7 @@ from edumfa.lib.policy import Match
 from edumfa.lib.error import PolicyError, eduMFAError
 import functools
 from edumfa.lib.policy import ACTION, SCOPE, ACTIONVALUE, LOGINMODE
+from edumfa.lib.tokenclass import AUTH_DATE_FORMAT
 from edumfa.lib.user import User
 from edumfa.lib.utils import parse_timelimit, parse_timedelta, split_pin_pass
 from edumfa.lib.authcache import verify_in_cache, add_to_cache
@@ -463,7 +464,7 @@ def auth_lastauth(wrapped_function, user_or_serial, passw, options=None):
             # set the last successful authentication, if res still true
             if res:
                 token.add_tokeninfo(ACTION.LASTAUTH,
-                                    datetime.datetime.now(tzlocal()))
+                                    datetime.datetime.now(tzlocal()).strftime(AUTH_DATE_FORMAT))
 
     return res, reply_dict
 

--- a/edumfa/lib/policydecorators.py
+++ b/edumfa/lib/policydecorators.py
@@ -32,9 +32,8 @@ from edumfa.lib.policy import Match
 from edumfa.lib.error import PolicyError, eduMFAError
 import functools
 from edumfa.lib.policy import ACTION, SCOPE, ACTIONVALUE, LOGINMODE
-from edumfa.lib.tokenclass import AUTH_DATE_FORMAT
 from edumfa.lib.user import User
-from edumfa.lib.utils import parse_timelimit, parse_timedelta, split_pin_pass
+from edumfa.lib.utils import parse_timelimit, parse_timedelta, split_pin_pass, LAST_AUTH_FORMAT
 from edumfa.lib.authcache import verify_in_cache, add_to_cache
 import datetime
 from dateutil.tz import tzlocal
@@ -464,7 +463,7 @@ def auth_lastauth(wrapped_function, user_or_serial, passw, options=None):
             # set the last successful authentication, if res still true
             if res:
                 token.add_tokeninfo(ACTION.LASTAUTH,
-                                    datetime.datetime.now(tzlocal()).strftime(AUTH_DATE_FORMAT))
+                                    datetime.datetime.now(tzlocal()).strftime(LAST_AUTH_FORMAT))
 
     return res, reply_dict
 

--- a/edumfa/lib/utils/__init__.py
+++ b/edumfa/lib/utils/__init__.py
@@ -63,6 +63,7 @@ CHARLIST_CONTENTPOLICY = {"c": string.ascii_letters, # characters
                           "n": string.digits,        # numbers
                           "s": string.punctuation}   # special
 
+LAST_AUTH_FORMAT = "%Y-%m-%d %H:%M:%S.%f%z"
 
 def check_time_in_range(time_range, check_time=None):
     """

--- a/edumfa/lib/utils/__init__.py
+++ b/edumfa/lib/utils/__init__.py
@@ -63,7 +63,7 @@ CHARLIST_CONTENTPOLICY = {"c": string.ascii_letters, # characters
                           "n": string.digits,        # numbers
                           "s": string.punctuation}   # special
 
-LAST_AUTH_FORMAT = "%Y-%m-%d %H:%M:%S.%f%z"
+LAST_AUTH_FORMAT = "%Y-%m-%d %H:%M:%S.%f%:z"
 
 def check_time_in_range(time_range, check_time=None):
     """


### PR DESCRIPTION
In the rare cases where the microseconds of a last_auth timestamp are 0, they were omitted:
```
>>> print(datetime(2025,6,1,12,0,0,0,tzinfo=tzlocal()))
2025-06-01 12:00:00+02:00
>>> print(datetime(2025,6,1,12,0,0,1,tzinfo=tzlocal()))
2025-06-01 12:00:00.000001+02:00
```
This change uses the format string '%Y-%m-%d %H:%M:%S.%f%:z'
 when writing the 'last_auth' time to tokeninfo,
 so nothing changes for timestamps with microseconds!=0, but we get a consistent format:
```
print(datetime(2025,6,1,12,0,0,0).strftime('%Y-%m-%d %H:%M:%S.%f%:z'))
2025-06-01 12:00:00.000000+02:00
```
