### PR TITLE
Remove specific package version definitions for Python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,8 +44,7 @@ cryptography==43.0.3
     #   pyopenssl
 defusedxml==0.7.1
     # via edumfa (setup.py)
-flask==3.0.3; python_version<'3.9'
-flask==3.1.0; python_version>='3.9'
+flask==3.1.0
     # via
     #   edumfa (setup.py)
     #   flask-babel
@@ -106,8 +105,7 @@ pycparser==2.22
     # via cffi
 pydash==8.0.4
     # via edumfa (setup.py)
-pyjwt==2.9.0; python_version<'3.9'
-pyjwt==2.10.1; python_version>='3.9'
+pyjwt==2.10.1
     # via edumfa (setup.py)
 pymysql==1.1.1
     # via edumfa (setup.py)


### PR DESCRIPTION
With the drop of Python 3.8 we missed a few packages that got a specific version for Python 3.8 defined. This PR removes these.