### PR TITLE
revert: fix: use format string for last auth timestamp

### DIFF
--- a/edumfa/lib/policydecorators.py
+++ b/edumfa/lib/policydecorators.py
@@ -33,7 +33,7 @@ from edumfa.lib.error import PolicyError, eduMFAError
 import functools
 from edumfa.lib.policy import ACTION, SCOPE, ACTIONVALUE, LOGINMODE
 from edumfa.lib.user import User
-from edumfa.lib.utils import parse_timelimit, parse_timedelta, split_pin_pass, LAST_AUTH_FORMAT
+from edumfa.lib.utils import parse_timelimit, parse_timedelta, split_pin_pass
 from edumfa.lib.authcache import verify_in_cache, add_to_cache
 import datetime
 from dateutil.tz import tzlocal
@@ -463,7 +463,7 @@ def auth_lastauth(wrapped_function, user_or_serial, passw, options=None):
             # set the last successful authentication, if res still true
             if res:
                 token.add_tokeninfo(ACTION.LASTAUTH,
-                                    datetime.datetime.now(tzlocal()).strftime(LAST_AUTH_FORMAT))
+                                    datetime.datetime.now(tzlocal()))
 
     return res, reply_dict
 

--- a/edumfa/lib/utils/__init__.py
+++ b/edumfa/lib/utils/__init__.py
@@ -63,7 +63,6 @@ CHARLIST_CONTENTPOLICY = {"c": string.ascii_letters, # characters
                           "n": string.digits,        # numbers
                           "s": string.punctuation}   # special
 
-LAST_AUTH_FORMAT = "%Y-%m-%d %H:%M:%S.%f%:z"
 
 def check_time_in_range(time_range, check_time=None):
     """


### PR DESCRIPTION
Reverts eduMFA/eduMFA#494
This caused a bug in 2.6.0. Format directive '%:z' was introduced in python 3.12, so we can not use it yet.