### PR TITLE
feat: use fixed format for last_auth timestamp in tokeninfo

### DIFF
--- a/edumfa/lib/policydecorators.py
+++ b/edumfa/lib/policydecorators.py
@@ -463,7 +463,7 @@ def auth_lastauth(wrapped_function, user_or_serial, passw, options=None):
             # set the last successful authentication, if res still true
             if res:
                 token.add_tokeninfo(ACTION.LASTAUTH,
-                                    datetime.datetime.now(tzlocal()))
+                                    datetime.datetime.now(tzlocal()).isoformat(sep=' ', timespec='microseconds'))
 
     return res, reply_dict
 

--- a/edumfa/lib/tokens/webauthntoken.py
+++ b/edumfa/lib/tokens/webauthntoken.py
@@ -1370,7 +1370,7 @@ class WebAuthnTokenClass(TokenClass):
                 reply_dict["type"] = token.token.tokentype
                 if count != -1:
                     token.add_tokeninfo(ACTION.LASTAUTH,
-                                        datetime.datetime.now(tzlocal()))
+                                        datetime.datetime.now(tzlocal()).isoformat(sep=' ', timespec='microseconds'))
                     token.inc_count_auth_success()
                     return True, reply_dict
                 else:

--- a/tests/test_lib_policydecorator.py
+++ b/tests/test_lib_policydecorator.py
@@ -477,6 +477,11 @@ class LibPolicyTestCase(MyTestCase):
         self.assertEqual(rv[0], True)
 
         token = get_tokens(serial=serial)[0]
+
+        # make sure last_auth tokeninfo is in expected ISO 8601 format
+        tokeninfo = token.token.get_info()
+        self.assertRegex(tokeninfo['last_auth'],r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}([+-]\d{2}:\d{2})?$')
+
         # Set a very old last_auth
         token.add_tokeninfo(ACTION.LASTAUTH,
                             datetime.datetime.utcnow()-datetime.timedelta(days=2))


### PR DESCRIPTION
In the rare cases where the microseconds of a last_auth timestamp are 0, they were omitted:
```python
>>> print(datetime(2025,1,14,12,0,0,0,tzinfo=tzlocal()))
2025-01-14 12:00:00+01:00
>>> print(datetime(2025,1,14,12,0,0,1,tzinfo=tzlocal()))
2025-01-14 12:00:00.000001+01:00
```

By default datetime uses `isoformat(sep=' ')` for the `__str__` functions,
which omits the microsecond fractions if they are 0.

This change uses datetime.isoformat(sep=' ', timespec='microseconds') to always get the microseconds.
```python
>>> print(datetime(2025,1,14,12,0,0,0,tzinfo=tzlocal()).isoformat(sep=' ', timespec='microseconds'))
2025-01-14 12:00:00.000000+01:00
```
