### PR TITLE
registration codes can be explicitly set via otpkey parameter

### DIFF
--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -226,7 +226,7 @@ registration.length
 type: int
 
 This is the length of the generated registration codes. This has no effect if
-the registration code is manually set via "optkey" parameter.
+the registration code is manually set via "otpkey" parameter.
 
 registration.contents
 ~~~~~~~~~~~~~~~~~~~~~
@@ -236,7 +236,7 @@ type: string
 contents: cns
 
 This defines what characters the registrationcodes should contain. This has no effect if
-the registration code is manually set via "optkey" parameter.
+the registration code is manually set via "otpkey" parameter.
 
 This takes the same values like the admin policy :ref:`admin_policies_otp_pin_contents`.
 

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -225,7 +225,8 @@ registration.length
 
 type: int
 
-This is the length of the generated registration codes.
+This is the length of the generated registration codes. This has no effect if
+the registration code is manually set via "optkey" parameter.
 
 registration.contents
 ~~~~~~~~~~~~~~~~~~~~~
@@ -234,7 +235,8 @@ type: string
 
 contents: cns
 
-This defines what characters the registrationcodes should contain.
+This defines what characters the registrationcodes should contain. This has no effect if
+the registration code is manually set via "optkey" parameter.
 
 This takes the same values like the admin policy :ref:`admin_policies_otp_pin_contents`.
 

--- a/edumfa/lib/policy.py
+++ b/edumfa/lib/policy.py
@@ -2152,12 +2152,12 @@ def get_static_policy_definitions(scope=None):
             ACTION.REGISTRATIONCODE_LENGTH: {
                 'type': 'int',
                 'value': list(range(1, 32)),
-                "desc": _("Set the length of registration codes."),
+                "desc": _("Set the length of registration codes. Only takes effect when key is generated."),
                 'group': GROUP.TOKEN},
             ACTION.REGISTRATIONCODE_CONTENTS: {
                 'type': 'str',
                 "desc": _("Specify the required "
-                          "contents of the registration code. "
+                          "contents of the registration code. Only takes effect when key is generated. "
                           "(c)haracters, (n)umeric, "
                           "(s)pecial. Use modifiers +/- or a list "
                           "of allowed characters [1234567890]"),

--- a/edumfa/lib/tokens/registrationtoken.py
+++ b/edumfa/lib/tokens/registrationtoken.py
@@ -164,8 +164,10 @@ class RegistrationTokenClass(PasswordTokenClass):
         :type param: dict
         :return: None
         """
-        # We always generate the registration code, so we need to set this parameter
-        param["genkey"] = 1
+        # If neither genkey or otpkey is given we always generate the key
+        if 'genkey' not in param and 'otpkey' not in param:
+            param['genkey'] = 1
+
         PasswordTokenClass.update(self, param)
 
     @log_with(log, log_entry=False)

--- a/tests/test_lib_tokens_registration.py
+++ b/tests/test_lib_tokens_registration.py
@@ -49,7 +49,6 @@ class RegistrationTokenTestCase(MyTestCase):
         registrationcode = init_detail.get("registrationcode")
         # the registrationcode should now equal the otpkey-param
         self.assertEqual("test_registration_key", registrationcode)
-        self.assertTrue(int(registrationcode))
 
     def test_02_class_methods(self):
         db_token = Token.query.filter(Token.serial == self.serial1).first()

--- a/tests/test_lib_tokens_registration.py
+++ b/tests/test_lib_tokens_registration.py
@@ -42,6 +42,15 @@ class RegistrationTokenTestCase(MyTestCase):
         registrationcode = init_detail.get("registrationcode")
         self.assertEqual(DEFAULT_LENGTH, len(registrationcode))
 
+    def test_01c_create_token_with_key(self):
+        token = init_token({"type": "registration",
+                            "otpkey": "test_registration_key"})
+        init_detail = token.get_init_detail()
+        registrationcode = init_detail.get("registrationcode")
+        # the registrationcode should now equal the otpkey-param
+        self.assertEqual("test_registration_key", registrationcode)
+        self.assertTrue(int(registrationcode))
+
     def test_02_class_methods(self):
         db_token = Token.query.filter(Token.serial == self.serial1).first()
         token = RegistrationTokenClass(db_token)


### PR DESCRIPTION
Registration codes (tokentype registration) are an easy way of initially rolling out a token. Right now these codes can only be generated by eduMFA. Since rollout processes often involve automatic token creation via API and are embedded in more complex processes, one might want to generate the otp-value in advance and then explicitly set it in eduMFA.

This PR removes the restriction that registration codes always set genkey to 1 and so makes it possible to set the otp via otpkey parameter as in many other token types.