### PR TITLE
fix session handling

### DIFF
--- a/edumfa/lib/auditmodules/sqlaudit.py
+++ b/edumfa/lib/auditmodules/sqlaudit.py
@@ -186,8 +186,7 @@ class Audit(AuditBase):
 
     def _finalize_session(self):
         """ Close current session and dispose connections of db engine"""
-        self.session.close()
-        self.engine.dispose()
+        self.session.remove()
 
     def _truncate_data(self):
         """

--- a/edumfa/lib/lifecycle.py
+++ b/edumfa/lib/lifecycle.py
@@ -21,7 +21,7 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
-from edumfa.lib.framework import get_request_local_store
+from edumfa.lib.framework import get_app_local_store
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ def register_finalizer(func):
     :param func: a function that takes no arguments
     """
     # from http://flask.pocoo.org/snippets/53/
-    store = get_request_local_store()
+    store = get_app_local_store()
     if 'call_on_teardown' not in store:
         store['call_on_teardown'] = []
     store['call_on_teardown'].append(func)
@@ -44,7 +44,7 @@ def call_finalizers():
     Call all finalizers that have been registered with the current request.
     Exceptions will be caught and written to the log.
     """
-    store = get_request_local_store()
+    store = get_app_local_store()
     if 'call_on_teardown' in store:
         for func in store['call_on_teardown']:
             try:
@@ -52,4 +52,3 @@ def call_finalizers():
             except Exception as exx:
                 log.warning("Caught exception in finalizer: {!r}".format(exx))
                 log.debug("Exception in finalizer:", exc_info=True)
-        store['call_on_teardown'] = []

--- a/edumfa/lib/resolvers/SQLIdResolver.py
+++ b/edumfa/lib/resolvers/SQLIdResolver.py
@@ -487,7 +487,7 @@ class IdResolver (UserIdResolver):
         # We use ``scoped_session``.
         self.session = scoped_session(sessionmaker(bind=self.engine))
         # Session should be closed on teardown
-        register_finalizer(self.session.close)
+        register_finalizer(self.session.remove)
         self.session._model_changes = {}
         self.TABLE = Table(self.table, MetaData(), autoload_with=self.engine)
 

--- a/tests/test_lib_lifecycle.py
+++ b/tests/test_lib_lifecycle.py
@@ -25,7 +25,7 @@ class LifecycleTestCase(MyTestCase):
         finalizer3.assert_not_called()
         register_finalizer(finalizer3)
         call_finalizers()
-        self.assertEqual(finalizer1.call_count,2)
+        self.assertEqual(finalizer1.call_count, 2)
         self.assertEqual(finalizer2.call_count, 2)
         finalizer3.assert_called_once()
 
@@ -50,7 +50,7 @@ class LifecycleTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             result = res.json.get("result")
             self.assertTrue(result.get("status"))
-        self.assertEqual(finalizer1.call_count,2)
+        self.assertEqual(finalizer1.call_count, 2)
         self.assertEqual(finalizer2.call_count, 2)
 
     def test_03_finalizer_error(self):

--- a/tests/test_lib_lifecycle.py
+++ b/tests/test_lib_lifecycle.py
@@ -23,11 +23,10 @@ class LifecycleTestCase(MyTestCase):
         finalizer1.assert_called_once()
         finalizer2.assert_called_once()
         finalizer3.assert_not_called()
-        # call_finalizer clears the list of finalizers
         register_finalizer(finalizer3)
         call_finalizers()
-        finalizer1.assert_called_once()
-        finalizer2.assert_called_once()
+        self.assertEqual(finalizer1.call_count,2)
+        self.assertEqual(finalizer2.call_count, 2)
         finalizer3.assert_called_once()
 
     def test_02_register_finalizer_request_context(self):
@@ -51,8 +50,8 @@ class LifecycleTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             result = res.json.get("result")
             self.assertTrue(result.get("status"))
-        finalizer1.assert_called_once()
-        finalizer2.assert_called_once()
+        self.assertEqual(finalizer1.call_count,2)
+        self.assertEqual(finalizer2.call_count, 2)
 
     def test_03_finalizer_error(self):
         finalizer1 = mock.MagicMock()


### PR DESCRIPTION
Right now the sessions are not cleanup correctly after each response. The finalizer is only called the first time and afterwards not registered again.