### PR TITLE
fix: make challenge cleanup & client applications more reslient

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/edumfa/models.py
+++ b/edumfa/models.py
@@ -42,7 +42,7 @@ from edumfa.lib.crypto import (encrypt,
 from sqlalchemy import and_
 from sqlalchemy.schema import Sequence, CreateSequence
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import OperationalError, IntegrityError
 from sqlalchemy import BigInteger
 from sqlalchemy.dialects import postgresql, mysql, sqlite
 from .lib.log import log_with
@@ -1490,8 +1490,8 @@ def cleanup_challenges():
     try:
         Challenge.query.filter(Challenge.expiration < c_now).delete()
         db.session.commit()
-    except Exception as e:
-        log.warning("Error in cleanup_challenges: {0!s}".format(e))        
+    except (OperationalError, IntegrityError) as e:
+        log.warning("Error in cleanup_challenges: {0!s}".format(e))
 
 # -----------------------------------------------------------------------------
 #
@@ -2596,7 +2596,7 @@ class ClientApplication(MethodsMixin, db.Model):
             try:
                 db.session.add(self)
                 db.session.commit()
-            except Exception as e:  # pragma: no cover
+            except (OperationalError, IntegrityError) as e:
                 log.warning('Unable to write ClientApplication entry to db: {0!s}'.format(e))
         else:
             # update
@@ -2606,7 +2606,7 @@ class ClientApplication(MethodsMixin, db.Model):
             try:
                 ClientApplication.query.filter(ClientApplication.id == clientapp.id).update(values)
                 db.session.commit()
-            except Exception as e:
+            except (OperationalError, IntegrityError) as e:
                 log.warning("Unable to update ClientApplication entry: {0!s}".format(e))
 
     def __repr__(self):

--- a/edumfa/models.py
+++ b/edumfa/models.py
@@ -1487,8 +1487,11 @@ def cleanup_challenges():
     :return: None
     """
     c_now = datetime.utcnow()
-    Challenge.query.filter(Challenge.expiration < c_now).delete()
-    db.session.commit()
+    try:
+        Challenge.query.filter(Challenge.expiration < c_now).delete()
+        db.session.commit()
+    except Exception as e:
+        log.warning("Error in cleanup_challenges: {0!s}".format(e))        
 
 # -----------------------------------------------------------------------------
 #
@@ -2590,18 +2593,21 @@ class ClientApplication(MethodsMixin, db.Model):
         self.lastseen = datetime.now()
         if clientapp is None:
             # create a new one
-            db.session.add(self)
+            try:
+                db.session.add(self)
+                db.session.commit()
+            except Exception as e:  # pragma: no cover
+                log.warning('Unable to write ClientApplication entry to db: {0!s}'.format(e))
         else:
             # update
             values = {"lastseen": self.lastseen}
             if self.hostname is not None:
                 values["hostname"] = self.hostname
-            ClientApplication.query.filter(ClientApplication.id == clientapp.id).update(values)
-        try:
-            db.session.commit()
-        except IntegrityError as e:  # pragma: no cover
-            log.info('Unable to write ClientApplication entry to db: {0!s}'.format(e))
-            log.debug(traceback.format_exc())
+            try:
+                ClientApplication.query.filter(ClientApplication.id == clientapp.id).update(values)
+                db.session.commit()
+            except Exception as e:
+                log.warning("Unable to update ClientApplication entry: {0!s}".format(e))
 
     def __repr__(self):
         return "<ClientApplication [{0!s}][{1!s}:{2!s}] on {3!s}>".format(


### PR DESCRIPTION
right now there are some minor corner cases where the session handling may crash under unclear corner cases.

Some of them are not that urgent and can simply get ignored by wrapping them into a try catch