### PR TITLE
chore: Drop support for ubuntu focal

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,17 +14,12 @@ jobs:
             codename: noble
           - os: ubuntu-22.04
             codename: jammy
-          - os: ubuntu-20.04
-            codename: focal
     name: Build for ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          if [ "${{ matrix.os }}" == "ubuntu-20.04" ]; then
-            sudo add-apt-repository ppa:jyrki-pulliainen/dh-virtualenv
-          fi
           sudo apt update
           sudo apt install -y build-essential debhelper devscripts equivs dh-virtualenv
       - name: Build core package
@@ -32,10 +27,6 @@ jobs:
           DH_VIRTUALENV_INSTALL_ROOT: /opt
         run: |
           mv deploy/ubuntu debian
-          if [ "${{ matrix.os }}" == "ubuntu-20.04" ]; then
-            sed -i "s/python3-all/python3.9/g" debian/control
-            sed -i "s/python3/python3.9/g" debian/rules
-          fi
           sed -i "s/{{CODENAME}}/${{ matrix.codename }}/g" debian/changelog
           sudo mk-build-deps -ri
           dpkg-buildpackage -us -uc -b --source-option=-Sa

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -7,7 +7,7 @@ The ways described here to install eduMFA are
 
  * the installation via the :ref:`pip_install`, which can be used on
    any Linux distribution.
- * ready made :ref:`install_ubuntu` for Ubuntu 20.04 LTS, 22.04 LTS and 24.04 LTS.
+ * ready made :ref:`install_ubuntu` for Ubuntu 22.04 LTS and 24.04 LTS.
  * the installation via :ref:`install_docker`.
 
 If you want to upgrade please read :ref:`upgrade`.

--- a/doc/installation/ubuntu.rst
+++ b/doc/installation/ubuntu.rst
@@ -5,7 +5,7 @@ Ubuntu Packages
 
 .. index:: ubuntu
 
-There are ready made packages for Ubuntu 20.04LTS, 22.04LTS and 24.04LTS.
+There are ready made packages for Ubuntu 22.04LTS and 24.04LTS.
 
 .. note:: The packages ``edumfa-apache2`` and ``edumfa-nginx`` assume
    that you want to run a eduMFA system. These packages deactivate all
@@ -41,25 +41,11 @@ The fingerprint of the key is::
 
 You now need to add the signing key to your system. The following instructions
 
-.. tab:: Ubuntu 24.04LTS
+.. code-block:: bash
 
-    .. code-block:: bash
+    mv eduMFA-Release.asc /etc/apt/trusted.gpg.d/eduMFA-Release.asc
 
-        mv eduMFA-Release.asc /etc/apt/trusted.gpg.d/eduMFA-Release.asc
-
-.. tab:: Ubuntu 22.04LTS
-
-    .. code-block:: bash
-
-        mv eduMFA-Release.asc /etc/apt/trusted.gpg.d/eduMFA-Release.asc
-
-.. tab:: Ubuntu 20.04LTS
-
-    .. code-block:: bash
-
-        apt-key add eduMFA-Release.asc
-
-Now you need to add the repository for your release (focal/20.04LTS, jammy/22.04LTS or noble/24.04LTS) You can do this by running the command:
+Now you need to add the repository for your release (jammy/22.04LTS or noble/24.04LTS) You can do this by running the command:
 
 .. tab:: Ubuntu 24.04LTS
 
@@ -72,12 +58,6 @@ Now you need to add the repository for your release (focal/20.04LTS, jammy/22.04
     .. code-block:: bash
 
         add-apt-repository http://bb-repo.zedat.fu-berlin.de/repository/edumfa-ubuntu-jammy
-
-.. tab:: Ubuntu 20.04LTS
-
-    .. code-block:: bash
-
-        add-apt-repository http://bb-repo.zedat.fu-berlin.de/repository/edumfa-ubuntu-focal
 
 As an alternative you can add the repo in a dedicated file. Create a new
 file ``/etc/apt/sources.list.d/eduMFA-community.list`` with the following contents:
@@ -93,12 +73,6 @@ file ``/etc/apt/sources.list.d/eduMFA-community.list`` with the following conten
     .. code-block:: bash
 
         deb http://bb-repo.zedat.fu-berlin.de/repository/edumfa-ubuntu-jammy jammy main
-
-.. tab:: Ubuntu 20.04LTS
-
-    .. code-block:: bash
-
-        deb http://bb-repo.zedat.fu-berlin.de/repository/edumfa-ubuntu-focal focal main
 
 
 Installation of eduMFA 1.x or higher
@@ -183,14 +157,6 @@ Update the Linux distribution version in the changelog file. For Ubuntu 24.04LTS
     .. code-block:: bash
 
         sed -i 's/{{CODENAME}}/jammy/g' debian/changelog
-
-.. tab:: Ubuntu 20.04LTS
-
-    .. code-block:: bash
-
-        sed -i 's/{{CODENAME}}/focal/g' debian/changelog
-        sed -i "s/python3-all/python3.9/g" debian/control
-        sed -i "s/python3/python3.9/g" debian/rules
 
 Install build dependencies and build the package::
 


### PR DESCRIPTION
This PR drops support for ubuntu focal due to following reasons:
- Standard support will be dropped in May this year
- There is no Github Runner available anymore to build packages
- This ubuntu version doesn't come with default Python 3.9 support (which is our current min version) and requires a somewhat hacky workaround