### PR TITLE
fix: delete existing connections when saving a resolver

### DIFF
--- a/edumfa/lib/resolver.py
+++ b/edumfa/lib/resolver.py
@@ -133,6 +133,10 @@ def save_resolver(params):
                        Type=types.get(key, ""),
                        Description=desc.get(key, "")).save()
 
+    # Delete exiting connections
+    store = get_app_local_store()
+    if "resolver_objects" in store:
+        store["resolver_objects"].pop(resolvername, None)
     # Remove corresponding entries from the user cache
     delete_user_cache(resolver=resolvername)
 


### PR DESCRIPTION
When modifying e.g. an LDAP connection, it currently re-uses the old configuration. Therefore delete the resolver object so it gets re-created on the next request, avoiding stale data.
I tested with the following resolvers:

- [x] LDAP
- [x] passwd
- [x] SQL
- [x] LDAP+passwd

I did not test with a SCIM or HTTP resolver.