### PR TITLE
feat: restart request dialog on ldapresolver change

### DIFF
--- a/edumfa/static/components/config/controllers/configControllers.js
+++ b/edumfa/static/components/config/controllers/configControllers.js
@@ -1079,6 +1079,9 @@ myApp.controller("LdapResolverController", ["$scope", "ConfigFactory", "$state",
         ConfigFactory.setResolver($scope.resolvername, $scope.params, function (data) {
             $scope.set_result = data.result.value;
             $scope.getResolvers();
+            // As we don't know whether resolvername already exists, just show
+            // the pop-up each time to keep things simple.
+            $scope.ldapRestartDialog();
             $state.go("config.resolvers.list");
         });
     };

--- a/edumfa/static/components/config/views/config.html
+++ b/edumfa/static/components/config/views/config.html
@@ -82,5 +82,5 @@
 </div>
 
 
-<ng-include src="instanceUrl + '/static/components/config/views/dialog.confirm_delete.html'">
-</ng-include>
+<ng-include src="instanceUrl + '/static/components/config/views/dialog.confirm_delete.html'"></ng-include>
+<ng-include src="instanceUrl + '/static/components/config/views/dialog.ldap_restart.html'"></ng-include>

--- a/edumfa/static/components/config/views/dialog.ldap_restart.html
+++ b/edumfa/static/components/config/views/dialog.ldap_restart.html
@@ -1,0 +1,26 @@
+    <!-- Modal -->
+    <div class="modal fade" id="dialogLdapRestart" tabindex="-1"
+         role="dialog"
+         aria-labelledby="myModalRestart"
+         aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal"
+                            aria-label="Close">
+                        <span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="myModalRestart" translate>
+                        Restart eduMFA
+                    </h4>
+                </div>
+                <div class="modal-body">
+                    <p translate>Please remember to restart eduMFA when modifying an existing LDAP resolver.</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default"
+                            data-dismiss="modal" translate>Close
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>

--- a/edumfa/static/components/login/controllers/loginControllers.js
+++ b/edumfa/static/components/login/controllers/loginControllers.js
@@ -640,6 +640,10 @@ angular.module("eduMfaApp")
         $scope.$broadcast("piReload");
     };
 
+    $scope.ldapRestartDialog = function() {
+        $("#dialogLdapRestart").modal("show");
+    };
+
 }]);
 
 angular.module("eduMfaApp")


### PR DESCRIPTION
When modifying e.g. an LDAP connection, it currently re-uses the old configuration. This adds a popup informing the user to restart their eduMFA:
![image](https://github.com/user-attachments/assets/c3363e80-253d-45e3-abd4-8ed146da836a)

Without additional complexity (e.g. requesting the current list of resolvers), it is unknown whether the `resolvername` already exists (i.e. whether we are editing an existing resolver or a new one). This is especially so since users able to enter any name into the editing mask even when pressing "New ldapresolver", potentially modifying an already existing resolver. To keep things simple the pop-up shows every time an LDAPresolver is saved.
fixes #670