### PR TITLE
fix reg token copy on firefox

### DIFF
--- a/edumfa/static/components/token/views/token.enrolled.registration.html
+++ b/edumfa/static/components/token/views/token.enrolled.registration.html
@@ -9,7 +9,7 @@
                         </span>
                     </div>
                 </uib-accordion-heading>
-                {{ enrolledToken.registrationcode }}
+                <div>{{ enrolledToken.registrationcode }}</div>
             </div>
         </uib-accordion>
 


### PR DESCRIPTION
Currently, copying via double click + ctrl+c copies a space before the token. This means the token in the clipboard is invalid. This can lead to confusion.