### PR TITLE
feat(firebase): add configurable timeouts for firebase requests

### DIFF
--- a/deploy/edumfa/edumfa.cfg
+++ b/deploy/edumfa/edumfa.cfg
@@ -24,3 +24,13 @@ EDUMFA_AUDIT_POOL_SIZE = 20
 
 EDUMFA_LOGFILE = '/var/log/edumfa/edumfa.log'
 EDUMFA_LOGLEVEL = logging.INFO
+
+
+# Timeout duration (in seconds) for establishing a connection to the Firebase server.
+# If the server does not respond within this time, the connection attempt is aborted.
+FIREBASE_CONNECT_TIMEOUT = 1.1
+
+# Timeout duration (in seconds) for waiting on a response *after* the connection is established.
+# This defines how long the system will wait for Firebase to process and respond to a request.
+FIREBASE_READ_TIMEOUT = 3.0
+

--- a/edumfa/lib/smsprovider/FirebaseProvider.py
+++ b/edumfa/lib/smsprovider/FirebaseProvider.py
@@ -160,13 +160,9 @@ class FirebaseProvider(ISMSProvider):
             server_config = json.load(f)
         url = FIREBASE_URL_SEND.format(server_config["project_id"])
         try:
-            FIREBASE_CONNECT_TIMEOUT = float(get_app_config_value("FIREBASE_CONNECT_TIMEOUT"))
-            if FIREBASE_CONNECT_TIMEOUT is None or not isinstance(FIREBASE_CONNECT_TIMEOUT, float):
-                FIREBASE_CONNECT_TIMEOUT = 1.1
+            FIREBASE_CONNECT_TIMEOUT = float(get_app_config_value("FIREBASE_CONNECT_TIMEOUT", default=1.1))
 
-            FIREBASE_READ_TIMEOUT = float(get_app_config_value("FIREBASE_READ_TIMEOUT"))
-            if FIREBASE_READ_TIMEOUT is None or not isinstance(FIREBASE_READ_TIMEOUT, float):
-                FIREBASE_READ_TIMEOUT = 3
+            FIREBASE_READ_TIMEOUT = float(get_app_config_value("FIREBASE_READ_TIMEOUT", default=3))
 
             log.debug(f"FIREBASE_CONNECT_TIMEOUT: {FIREBASE_CONNECT_TIMEOUT}")
             log.debug(f"FIREBASE_READ_TIMEOUT: {FIREBASE_READ_TIMEOUT}")

--- a/edumfa/lib/smsprovider/FirebaseProvider.py
+++ b/edumfa/lib/smsprovider/FirebaseProvider.py
@@ -173,20 +173,15 @@ class FirebaseProvider(ISMSProvider):
             resp = authed_session.post(url, data=json.dumps(fcm_message), headers=headers, proxies=proxies, timeout=(FIREBASE_CONNECT_TIMEOUT,FIREBASE_READ_TIMEOUT))
             if resp.status_code == 200:
                 log.debug("Message sent successfully to Firebase service.")
-                res = True
+                return True
             else:
                 log.warning("Failed to send message to firebase service: {0!s}".format(resp.text))
+                return False
 
         except Exception as e:
             log.warning(f"An unexpected error occurred in Firebase.py: {e}")
+            return False
 
-        if resp.status_code == 200:
-            log.debug("Message sent successfully to Firebase service.")
-            res = True
-        else:
-            log.warning("Failed to send message to firebase service: {0!s}".format(resp.text))
-
-        return res
 
     def check_configuration(self):
         """


### PR DESCRIPTION
…w polling if firebase is down with Shibboleth frontend proxy.

Hello there,
At the University of Bamberg, we use [Shibboleth](https://en.wikipedia.org/wiki/Shibboleth_(software)) as our authentication agent. It integrates well with edumfa. We were concerned about reliability if the internet went down or Firebase isn't reachable anymore. We blocked all Google Firebase API servers via our firewall to test the polling method. Each time, after 60 seconds, Shibboleth would kick you out because it thought the service had gone down, while it was processing in the background for a long time.

### What we Changed
#### Added Try-Except Statement

We added a try-except statement around the POST request to the Firebase server. So if the server isn't reachable, it would not crash.
#### Added Timeout

We added a timeout parameter to the Firebase request so that google.auth + request wouldn't try forever to connect to Firebase. We also added configurable parameters to edumfa.cfg to change the timeout parameters.

There was already a similar attempt #338, but the issue isn't fixed yet #275.