### PR TITLE
docs: add hardware requirements rec and some fixes

### DIFF
--- a/doc/faq/customization.rst
+++ b/doc/faq/customization.rst
@@ -23,7 +23,7 @@ All HTML views are contained in::
 
     static/components/<component>/views/<view>.html
 
-You can find them on `GitHub <https://github.com/eduMFA/eduMFA/tree/master/eduMFA/static>`_
+You can find them on `GitHub <https://github.com/eduMFA/eduMFA/tree/main/edumfa/static>`_
 or at the according location in your installation.
 
 Follow these basic steps:

--- a/doc/installation/system/edumfa-manage.rst
+++ b/doc/installation/system/edumfa-manage.rst
@@ -57,7 +57,7 @@ Backup and Restore
 
 .. index:: Backup, Restore
 
-You can create a backup which will be save to */var/lib/edumfa/backup/*.
+You can create a backup which will be saved to */var/lib/edumfa/backup/*.
 
 The backup will contain the database dump and the complete directory
 */etc/edumfa*. You may choose if you want to add the encryption key to

--- a/doc/overview/index.rst
+++ b/doc/overview/index.rst
@@ -18,15 +18,15 @@ Other concepts like handling of machines or enrolling certificates
 are coming up, you may monitor this development on Github.
 
 eduMFA is a web application written in Python based on the
-`flask micro framework`_. You can use any webserver with a wsgi interface
+`Flask microframework`_. You can use any webserver with a wsgi interface
 to run eduMFA. E.g. this can be Apache, Nginx or even `werkzeug`_.
 
 A device or item used to authenticate is still called a
 "token". All token information is stored in an SQL database,
-while you may choose, which database you want to use.
+while you may choose which database you want to use.
 eduMFA uses `SQLAlchemy`_ to map the database to
 internal objects. Thus you may choose to run eduMFA
-with SQLite, MySQL, PostgreSQL, Oracle, DB2 or other database.
+with SQLite, MySQL, PostgreSQL, Oracle, DB2 or other databases.
 
 The code is divided into three layers, the API, the library and the
 database layer. Read about it at :ref:`code_docu`.
@@ -47,6 +47,18 @@ We will take a look at common ways to setup eduMFA
 in the section :ref:`installation`
 but there are still many others.
 
-.. _flask micro framework: https://flask.palletsprojects.com/
+Hardware Requirements
+---------------------
+
+The hardware requirements are dependant on the amount of traffic you anticipate. As a starting point, an eduMFA VM could have these specs:
+
+* 2 CPU cores
+* 8GB RAM
+* 40GB Storage
+
+See :ref:`performance` for more information.
+
+
+.. _Flask microframework: https://flask.palletsprojects.com/
 .. _SQLAlchemy: https://www.sqlalchemy.org/
 .. _werkzeug: https://werkzeug.palletsprojects.com/

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -528,6 +528,17 @@ the entity whose web applications the WebAuthn tokens are used for.
     an overview of all the settings required for the use of WebAuthn, see
     :ref:`webauthn_otp_token`.
 
+.. _policy_webauthn_enroll_resident_key
+
+webauthn_resident_key
+~~~~~~~~~~~~~~~~~~~~~
+
+type: string
+
+Whether to request a resident key to be created.
+
+.. note:: Passkeys are always resident keys.
+
 .. _policy_webauthn_enroll_timeout:
 
 webauthn_timeout
@@ -702,7 +713,7 @@ by an unknown certificate.
     :ref:`webauthn_otp_token` for details.
 
 .. note:: If this is set to `untrusted`, a manipulated token could send a
-    self-signed attestation message with modified a modified AAGUID and faked
+    self-signed attestation message with a modified AAGUID and faked
     certificate fields in order to bypass :ref:`policy_webauthn_enroll_req` and
     :ref:`policy_webauthn_enroll_authenticator_selection_list`, or
     :ref:`policy_webauthn_authz_req` and

--- a/edumfa/lib/tokens/webauthntoken.py
+++ b/edumfa/lib/tokens/webauthntoken.py
@@ -70,7 +70,7 @@ WebAuthn tokens can be either
  * registered by the users themselves.
 
 Be aware that WebAuthn tokens can only be used if the eduMFA server and
-the applicaedumfations and services the user needs to access all reside under the
+the applications and services the user needs to access all reside under the
 same domain or subdomains thereof.
 
 This means a WebAuthn token registered by mfa.mycompany.com can be
@@ -146,7 +146,7 @@ and a message to display to the user. It will also contain some additional optio
 regarding timeout, which authenticators are acceptable, and what key types are
 acceptable to the server.
 
-With the received data You need to call the javascript function
+With the received data you need to call this javascript function:
 
 .. sourcecode:: javascript
 

--- a/edumfa/translations/cs/LC_MESSAGES/messages.po
+++ b/edumfa/translations/cs/LC_MESSAGES/messages.po
@@ -2870,7 +2870,7 @@ msgstr ""
 #~ "The URL of a repository, where the"
 #~ " policy templates can be found.  "
 #~ "(Default https: //raw.githubusercontent.com/ edumfa"
-#~ "/policy-templates /master/templates/)"
+#~ "/policy-templates/master/templates/)"
 #~ msgstr ""
 
 #~ msgid ""

--- a/edumfa/translations/de/LC_MESSAGES/messages.po
+++ b/edumfa/translations/de/LC_MESSAGES/messages.po
@@ -1173,7 +1173,7 @@ msgid ""
 "templates/main/templates/)"
 msgstr ""
 "Die URL der Policy-Templates. (Default https://raw.githubusercontent.com/"
-" edumfa/policy-templates/master/templates/)"
+"edumfa/policy-templates/master/templates/)"
 
 #: lib/policy.py:2467
 msgid ""

--- a/edumfa/translations/it/LC_MESSAGES/messages.po
+++ b/edumfa/translations/it/LC_MESSAGES/messages.po
@@ -2985,7 +2985,7 @@ msgstr ""
 #~ "The URL of a repository, where the"
 #~ " policy templates can be found.  "
 #~ "(Default https: //raw.githubusercontent.com/ edumfa"
-#~ "/policy-templates /master/templates/)"
+#~ "/policy-templates/master/templates/)"
 #~ msgstr ""
 
 #~ msgid ""

--- a/edumfa/translations/nl/LC_MESSAGES/messages.po
+++ b/edumfa/translations/nl/LC_MESSAGES/messages.po
@@ -1148,8 +1148,8 @@ msgid ""
 "templates/main/templates/)"
 msgstr ""
 "De URL van een opslagruimte waar de beleidssjablonen kunnen worden "
-"gevonden worden. (Standaard https: //raw.githubusercontent.com/ edumfa"
-"/policy-templates /master/templates/)"
+"gevonden worden. (Standaard https://raw.githubusercontent.com/edumfa"
+"/policy-templates/master/templates/)"
 
 #: lib/policy.py:2467
 msgid ""

--- a/edumfa/translations/pl/LC_MESSAGES/messages.po
+++ b/edumfa/translations/pl/LC_MESSAGES/messages.po
@@ -2823,7 +2823,7 @@ msgstr ""
 #~ "The URL of a repository, where the"
 #~ " policy templates can be found.  "
 #~ "(Default https: //raw.githubusercontent.com/ edumfa"
-#~ "/policy-templates /master/templates/)"
+#~ "/policy-templates/master/templates/)"
 #~ msgstr ""
 
 #~ msgid ""

--- a/edumfa/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/edumfa/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1135,8 +1135,8 @@ msgid ""
 "templates/main/templates/)"
 msgstr ""
 "A URL de um repositório, onde os modelos de políticas podem ser "
-"encontrados.  (https predefinidos: //raw.githubusercontent.com/ edumfa"
-"/policy-templates /master/templates/)"
+"encontrados.  (predefinidos https://raw.githubusercontent.com/edumfa"
+"/policy-templates/master/templates/)"
 
 #: lib/policy.py:2467
 msgid ""

--- a/edumfa/translations/ro/LC_MESSAGES/messages.po
+++ b/edumfa/translations/ro/LC_MESSAGES/messages.po
@@ -2892,7 +2892,7 @@ msgstr ""
 #~ "The URL of a repository, where the"
 #~ " policy templates can be found.  "
 #~ "(Default https: //raw.githubusercontent.com/ edumfa"
-#~ "/policy-templates /master/templates/)"
+#~ "/policy-templates/master/templates/)"
 #~ msgstr ""
 
 #~ msgid ""

--- a/edumfa/translations/ru/LC_MESSAGES/messages.po
+++ b/edumfa/translations/ru/LC_MESSAGES/messages.po
@@ -2967,7 +2967,7 @@ msgstr ""
 #~ "The URL of a repository, where the"
 #~ " policy templates can be found.  "
 #~ "(Default https: //raw.githubusercontent.com/ edumfa"
-#~ "/policy-templates /master/templates/)"
+#~ "/policy-templates/master/templates/)"
 #~ msgstr ""
 
 #~ msgid "More than one matching token were found."

--- a/edumfa/translations/si/LC_MESSAGES/messages.po
+++ b/edumfa/translations/si/LC_MESSAGES/messages.po
@@ -2823,7 +2823,7 @@ msgstr ""
 #~ "The URL of a repository, where the"
 #~ " policy templates can be found.  "
 #~ "(Default https: //raw.githubusercontent.com/ edumfa"
-#~ "/policy-templates /master/templates/)"
+#~ "/policy-templates/master/templates/)"
 #~ msgstr ""
 
 #~ msgid ""

--- a/edumfa/translations/tr/LC_MESSAGES/messages.po
+++ b/edumfa/translations/tr/LC_MESSAGES/messages.po
@@ -1147,9 +1147,8 @@ msgid ""
 "(Default https://raw.githubusercontent.com/eduMFA/policy-"
 "templates/main/templates/)"
 msgstr ""
-"Politika şablonlarının bulunabileceği bir depo URL'si. (Varsayılan https:"
-" //raw.githubusercontent.com/ PrivaciDiDea / Politika-şablonlar / Master "
-"/ Şablonlar /)"
+"Politika şablonlarının bulunabileceği bir depo URL'si.  (Varsayılan "
+"https://raw.githubusercontent.com/eduMFA/policy-templates/main/templates/"
 
 #: lib/policy.py:2467
 msgid ""

--- a/edumfa/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/edumfa/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -979,8 +979,8 @@ msgid ""
 "(Default https://raw.githubusercontent.com/eduMFA/policy-"
 "templates/main/templates/)"
 msgstr ""
-"可以在其中找到策略模板的存储库的URL。  （默认https：//raw.githubusercontent.com/ edumfa / "
-"policy-templates / master / templates /）"
+"可以在其中找到策略模板的存储库的URL。  （默认https：//raw.githubusercontent.com/edumfa/"
+"policy-templates/master/templates/）"
 
 #: lib/policy.py:2467
 msgid ""

--- a/edumfa/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/edumfa/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -982,8 +982,8 @@ msgid ""
 "(Default https://raw.githubusercontent.com/eduMFA/policy-"
 "templates/main/templates/)"
 msgstr ""
-"存儲庫的 URL，可在其中找到策略範本。 （默認 https: //raw.githubusercontent.com/ edumfa"
-"/policy-templates /master/templates/）"
+"存儲庫的 URL，可在其中找到策略範本。 （默認 https://raw.githubusercontent.com/edumfa"
+"/policy-templates/master/templates/）"
 
 #: lib/policy.py:2467
 msgid ""


### PR DESCRIPTION
This adds a small section on the overview so people have _some_ idea where to start for an eduMFA VM. In the long run maybe some real numbers from deployments could be added (requests/second, load, specs, etc)?  

<img width="1618" height="512" alt="grafik" src="https://github.com/user-attachments/assets/00156564-2552-4102-9f03-cc6ef203576e" />

Also fixes some mistakes in the documentation which I've been collecting.