### PR TITLE
fix: only show attributes if change is allowed

### DIFF
--- a/edumfa/static/components/user/views/user.details.html
+++ b/edumfa/static/components/user/views/user.details.html
@@ -75,7 +75,7 @@
     </div>
     -->
 
-    <div ng-show="allowed_custom_attributes.hasOwnProperty('set') || allowed_custom_attributes.hasOwnProperty('delete')">
+    <div ng-show="allowed_custom_attributes['set'].length > 0 || allowed_custom_attributes['delete'].length > 0">
         <h3 translate>Custom attributes for user {{ username }}</h3>
         <table class="table table-hover">
             <tr ng-repeat="(attribute_key, attribute_value) in custom_attributes">
@@ -92,7 +92,7 @@
                 </td>
             </tr>
         </table>
-        <div ng-show="allowed_custom_attributes.hasOwnProperty('set')">
+        <div ng-show="allowed_custom_attributes['set'].length > 0">
         <h4 translate>Add custom attribute</h4>
             <table class="table table-hover">
              <tr>

--- a/edumfa/static/components/user/views/user.details.html
+++ b/edumfa/static/components/user/views/user.details.html
@@ -75,7 +75,7 @@
     </div>
     -->
 
-    <div ng-show="allowed_custom_attributes['set'].length > 0 || allowed_custom_attributes['delete'].length > 0">
+    <div ng-show="(allowed_custom_attributes.hasOwnProperty('set') && allowed_custom_attributes['set'].length > 0) || (allowed_custom_attributes.hasOwnProperty('delete') && allowed_custom_attributes['delete'].length > 0)">
         <h3 translate>Custom attributes for user {{ username }}</h3>
         <table class="table table-hover">
             <tr ng-repeat="(attribute_key, attribute_value) in custom_attributes">

--- a/edumfa/static/components/user/views/user.details.html
+++ b/edumfa/static/components/user/views/user.details.html
@@ -92,7 +92,7 @@
                 </td>
             </tr>
         </table>
-        <div ng-show="allowed_custom_attributes['set'].length > 0">
+        <div ng-show="allowed_custom_attributes.hasOwnProperty('set') && allowed_custom_attributes['set'].length > 0">
         <h4 translate>Add custom attribute</h4>
             <table class="table table-hover">
              <tr>


### PR DESCRIPTION
The attribute list is always shown to admins even if they are not allowed to set/delete them.
This is because the template looks for existance of the key and [policy.py](https://github.com/eduMFA/eduMFA/blob/main/edumfa/lib/policy.py#L2945) always returns a object with the key set. If the user has no rights the keys are also set but the list ist empty. This change updates the template to reflect this.