### PR TITLE
feat: enable alembic logging

### DIFF
--- a/deploy/docker/logging.cfg
+++ b/deploy/docker/logging.cfg
@@ -18,6 +18,18 @@
             "handlers": ["stdhandler"],
             "level": "INFO"
         },
+        "alembic": {
+            "handlers": ["stdhandler"],
+            "qualname": "alembic",
+            "level": "INFO",
+            "propagate": 0
+        },
+       "sqlalchemy.engine": {
+            "handlers": ["stdhandler"],
+            "qualname": "sqlalchemy.engine",
+            "level": "WARN",
+            "propagate": 0
+        },
         "edumfa": {
             "handlers": ["stdhandler"],
             "qualname": "edumfa",

--- a/edumfa/lib/log.py
+++ b/edumfa/lib/log.py
@@ -46,6 +46,12 @@ DEFAULT_LOGGING_CONFIG = {
         }
     },
     "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+            "formatter": "detail",
+            "level": "INFO",
+        },
         "file": {
             "formatter": "detail",
             "class": "logging.handlers.RotatingFileHandler",
@@ -55,10 +61,24 @@ DEFAULT_LOGGING_CONFIG = {
             "filename": "edumfa.log"
         }
     },
-    "loggers": {"edumfa": {"handlers": ["file"],
-                                "qualname": "edumfa",
-                                "level": logging.INFO}
-                }
+    "loggers": {
+        "edumfa": {
+            "handlers": ["file"],
+            "qualname": "edumfa",
+            "level": logging.INFO,
+            "propagate": 0
+        },
+        "alembic": {
+            "handlers": ["console"],
+            "qualname": "alembic",
+            "level": logging.INFO,
+            "propagate": 0
+        },
+        "root": {
+            "handlers": ["console"],
+            "level": logging.WARN,
+        }
+    }
 }
 
 

--- a/edumfa/lib/log.py
+++ b/edumfa/lib/log.py
@@ -74,10 +74,6 @@ DEFAULT_LOGGING_CONFIG = {
             "level": logging.INFO,
             "propagate": 0
         },
-        "root": {
-            "handlers": ["console"],
-            "level": logging.WARN,
-        }
     }
 }
 

--- a/edumfa/lib/log.py
+++ b/edumfa/lib/log.py
@@ -66,13 +66,11 @@ DEFAULT_LOGGING_CONFIG = {
             "handlers": ["file"],
             "qualname": "edumfa",
             "level": logging.INFO,
-            "propagate": 0
         },
         "alembic": {
             "handlers": ["console"],
             "qualname": "alembic",
             "level": logging.INFO,
-            "propagate": 0
         },
     }
 }


### PR DESCRIPTION
Until now alembic migrations did not output any log messages. The most of these are actually pretty helpful. 

-> Enable them in the default logging config and the provided config for docker. 

In case of the docker version we ship a default handler so the propagation has to be stopped to prevent duplicate log messages.  