### PR TITLE
fix migration 414079706620 for mysql upgrades

### DIFF
--- a/migrations/versions/414079706620_.py
+++ b/migrations/versions/414079706620_.py
@@ -31,6 +31,7 @@ def upgrade():
         existing_type=sa.Integer(),
         type_=BigIntegerType,
         existing_nullable=False,
+        existing_autoincrement=True,
     )
     print("Setting challenge.id to bigint")
     op.alter_column(
@@ -39,6 +40,7 @@ def upgrade():
         existing_type=sa.Integer(),
         type_=BigIntegerType,
         existing_nullable=False,
+        existing_autoincrement=True,
     )
     pass
 
@@ -59,5 +61,6 @@ def downgrade():
         existing_type=BigIntegerType,
         type_=sa.Integer(),
         existing_nullable=False,
+        existing_autoincrement=True,
     )
     pass


### PR DESCRIPTION
When applying the 414079706620 migration as an upgrade on MySQL, both `id` columns lose their AUTO_INCREMENT. 
This PR fixes that as described in this issue: https://github.com/sqlalchemy/alembic/issues/413

Strangely this does not happen on `edumfa-manage create_tables` (Maybe because the type is already bigint? Not sure when/why it is bigint or int before this migrations).  
On MariaDB the database gets created with sequences, meaning there is no AUTO_INCREMENT to be lost.