### PR TITLE
image: support template customization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ COPY ./deploy/gunicorn/edumfaapp.py /opt/edumfa/app.py
 # Create directory for user scripts
 RUN mkdir -p /opt/edumfa/user-scripts
 
+# Link the edumfa package at a predicatable position for template overriding.
+RUN python_package_path="$(python3 -c 'import site; x=site.getsitepackages(); assert len(x) == 1; print(x[0])')" && \
+    ln -s "${python_package_path}/edumfa/" "/opt/edumfa/edumfa-package"
+
 EXPOSE 8000
 HEALTHCHECK --interval=5s --timeout=3s --start-period=60s --retries=2 CMD curl --fail http://localhost:8000/ || exit 1
 WORKDIR /opt/edumfa

--- a/deploy/docker-example/docker-compose.yml
+++ b/deploy/docker-example/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - edumfa-keys:/etc/edumfa/:rw
       - ./edumfa-setup.sh:/opt/edumfa/user-scripts/01-setup.sh:ro
       - ./example-policy.py:/opt/edumfa/policy.py:ro
+      - ./my-login.html:/opt/edumfa/edumfa-package/static/components/login/views/login.html
     environment:
       DB_DRIVER: ${DB_DRIVER}
       DB_HOSTNAME: mariadb

--- a/deploy/docker-example/my-login.html
+++ b/deploy/docker-example/my-login.html
@@ -1,0 +1,95 @@
+<div class="well" ng-show="hsmReady === 'True'">
+
+    <div class="container" ng-show="!loginWithCredentials">
+        <form name="formRemoteUserLogin" class="form-signin" role="form">
+            <div class="text-center">
+                <img ng-src="{{ instanceUrl }}/static/css/{{ piLogo }}"
+                     width="90px">
+            </div>
+            <h2 class="form-signin-heading" translate>Login as
+                {{ remoteUser }}</h2>
+
+            <p translate>
+                You are authenticated by the web server as user
+                <b>{{ remoteUser }}</b>.
+                You may login as this user to eduMFA without any further
+                credentials.
+            </p>
+
+            <div class="text-center">
+                <button ng-click="authenticate_remote_user()"
+                        class="btn btn-primary btn-block" translate>Log In
+                </button>
+                <button ng-hide="forceRemoteUser === 'True'"
+                        ng-click="loginWithCredentials = true"
+                        class="btn btn-info btn-block" translate>
+                    Login with credentials
+                </button>
+            </div>
+        </form>
+    </div>
+
+    <div ng-show="loginWithCredentials">
+        <div class="alert alert-info alert-dismissible" role="alert">
+            <button type="button" class="close" data-dismiss="alert"
+                    aria-label="Close">
+                <span aria-hidden="true">&times;</span></button>
+	    This is an example modification.
+        </div>
+
+
+
+        <div class="container">
+            <div class="text-center">
+                    <img ng-src="{{ instanceUrl }}/static/css/{{ piLogo }}"
+                         width="90px">
+                </div>
+            <div class="text-center">
+                <h2 ng-hide="piLoginText" class="form-signin-heading" translate>Please sign in</h2>
+                <h2 ng-show="piLoginText" class="form-signin-heading">{{ piLoginText }}</h2>
+            </div>
+            <form name="formSignin" class="form-signin" role="form" novalidate>
+                <label for="username" class="sr-only" translate>Username</label>
+                <input name="username" id="username"
+                       class="form-control round-top"
+                       ng-model="login.username" required
+                       placeholder="{{ 'Username'|translate }}"
+                       autofocus/>
+                <label for="realm" class="sr-only" translate>Realm</label>
+                <select class="form-control round-none"
+                        name="realm"
+                        placeholder="Realm"
+                        ng-show="piRealms.length > 0"
+                        id="realm"
+                        ng-model="login.realm"
+                        ng-options="realm for realm in piRealms">
+                    <!-- We add a placeholder, if we do not have an empty realm -->
+                    <option ng-hide="piRealms[0]===''" value="" selected translate>Choose a realm...</option>
+                </select>
+                <label for="password" class="sr-only" translate>Password</label>
+                <input name="password" type="password"
+                       id="password" class="form-control round-bottom"
+                       ng-model="login.password" required
+                       placeholder="{{ 'Password'|translate }}"/>
+
+                <div class="text-center">
+                    <button ng-click="authenticate_first();"
+                            ng-disabled="formSignin.$invalid"
+                            class="btn btn-primary btn-block" translate>Log In
+                    </button>
+                    <p class="text-right" ng-show="passwordReset === 'True'">
+                        <a ui-sref="recovery" translate>Reset Password</a>
+                    </p>
+                </div>
+
+            </form>
+        </div>
+    </div>
+</div>
+
+<div class="well" ng-show="hsmReady === 'False'">
+    <div class="alert alert-danger" role="alert" translate>
+        The HSM is not ready. eduMFA can not work properly. Please start
+        the HSM and reload this page.
+    </div>
+</div>

--- a/doc/faq/customization.rst
+++ b/doc/faq/customization.rst
@@ -55,6 +55,29 @@ Follow these basic steps:
 .. warning:: Of course - if there are functional enhancements or bug fixes in the
    original templates - your template will also not be affected by these.
 
+Templates (Docker)
+..................
+
+In the Docker image, you can modify templates by mounting them over their
+original paths. To change the *login.html* template, you would:
+
+1. Copy and modify the file at */edumfa/static/components/login/views/login.html*
+2. Mount that file at */opt/edumfa/edumfa-package/static/components/login/views/login.html*
+
+In a compose file, it could look like this:
+
+.. code-block:: yaml
+
+   services:
+     [...]
+     edumfa:
+       [...]
+       volumes:
+         [...]
+         - ./your-login.html:/opt/edumfa/edumfa-package/static/components/login/views/login.html
+
+.. warning:: If there are functional enhancements or bug fixes in the
+   original templates, remember to update your customized copy, too!
 
 Translating templates
 .....................


### PR DESCRIPTION
The currently recommended way by the documentation to customize templates requires changing the reverse proxy potentially outside of the eduMFA compose file.  
This patch documents a way for users to instead just mount them over existing files. ~It requires us to update the symlink if we update the Python version.~