### PR TITLE
chore: add edumfa-manage to linting and formatting

### DIFF
--- a/edumfa-manage
+++ b/edumfa-manage
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # License:  AGPLv3
 # This file is part of eduMFA. eduMFA is a fork of privacyIDEA which was forked from LinOTP.
@@ -31,5 +30,5 @@
 
 from edumfa.commands.manage.main import cli as manage_cli
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     manage_cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ include = ["edumfa*"]
 
 [tool.ruff]
 extend-include = [
+    "edumfa-manage",
     "tools/creategoogleauthenticator-file",
     "tools/edumfa-create-ad-users",
     "tools/edumfa-create-certificate",


### PR DESCRIPTION
This pr adds `edumfa-manage` to ruffs linting and formatting. It was ignored before, due to missing .py extension