### PR TITLE
dashboard: fix auth counts

### DIFF
--- a/edumfa/static/components/dashboard/controllers/dashboardControllers.js
+++ b/edumfa/static/components/dashboard/controllers/dashboardControllers.js
@@ -106,11 +106,11 @@ myApp.controller("dashboardController", ["ConfigFactory", "TokenFactory",
 
 $scope.getAuthentication = function () {
   $scope.authentications = {"success": 0, "fail": 0};
-  AuditFactory.get({"timelimit": "1d", "action": "*validate*", "success": "1"},
+  AuditFactory.get({"timelimit": "1d", "action": "*validate/*check", "success": "1"},
       function (data) {
           $scope.authentications.success = data.result.value.count;
       });
-  AuditFactory.get({"timelimit": "1d", "action": "*validate*", "success": "0"},
+  AuditFactory.get({"timelimit": "1d", "action": "*validate/*check", "success": "0"},
       function (data) {
           $scope.authentications.fail = data.result.value.count;
           $scope.authentications.users = {}; // Declare the users object as a dictionary


### PR DESCRIPTION
current request: `/audit/?action=*validate*&success=1&timelimit=1d`  
This leads to e.g. `triggerchallenge` being counted, leading to inflated numbers. Failure counts will still be inflated due to fudiscr's design.

https://edumfa.readthedocs.io/en/v2.8.0/modules/api/validate.html