### PR TITLE
set permissions when creating files not after

### DIFF
--- a/edumfa/commands/manage/config.py
+++ b/edumfa/commands/manage/config.py
@@ -263,13 +263,17 @@ def export_full_config(passwords, archive, directory):
         config_backup_file_base = f"{directory}/{base_name}-{hostname}-{date}"
         config_backup_file = f"{config_backup_file_base}.py"
 
-        with open(config_backup_file, "w") as f:
+        descriptor = os.open(path=config_backup_file, mode=0o600, flags=(os.O_WRONLY | os.O_CREAT))
+        with open(descriptor, "w") as f:
             conf_export(data, f)
         if archive:
             config_backup_archive = f"{config_backup_file_base}.tar.gz"
-            tar = tarfile.open(config_backup_archive, "w:gz")
-            tar.add(config_backup_file)
-            tar.close()
+            # create file with correct permissions
+            archive_descriptor = os.open(path=config_backup_archive, mode=0o600, flags=(os.O_WRONLY | os.O_CREAT))
+            os.close(archive_descriptor)
+            # write to file
+            with tarfile.open(config_backup_archive, "w:gz") as tar:
+                tar.add(config_backup_file)
             # cleanup
             if tarfile.is_tarfile(config_backup_archive):
                 os.remove(config_backup_file)

--- a/edumfa/commands/manage/core.py
+++ b/edumfa/commands/manage/core.py
@@ -95,7 +95,8 @@ def create_enckey(enckey_b64=None):
     if os.path.isfile(filename):
         click.echo(f"The file '{filename}' already exists.")
         sys.exit(1)
-    with open(filename, "wb") as f:
+    descriptor = os.open(path=filename, mode=0o400, flags=(os.O_WRONLY | os.O_CREAT))
+    with open(descriptor, "wb") as f:
         if enckey_b64 is None:
             f.write(DefaultSecurityModule.random(96))
         else:
@@ -106,9 +107,7 @@ def create_enckey(enckey_b64=None):
                 sys.exit(1)
             f.write(bin_enckey)
     click.echo(f"Encryption key written to {filename}")
-    os.chmod(filename, 0o400)
-    click.echo(f"The file permission of {filename} was set to 400!")
-    click.echo("Please ensure, that it is owned by the right user.")
+    click.echo("Please ensure that it is owned by the right user.")
 
 
 @core_cli.command("create_pgp_keys")
@@ -178,7 +177,9 @@ def create_audit_keys(keysize):
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
     )
-    with open(filename, "wb") as f:
+
+    descriptor = os.open(path=filename, mode=0o400, flags=(os.O_WRONLY | os.O_CREAT))
+    with open(descriptor, "wb") as f:
         f.write(priv_pem)
 
     pub_key = new_key.public_key()
@@ -192,8 +193,6 @@ def create_audit_keys(keysize):
     click.echo(
         f"Signing keys written to {filename} and {current_app.config.get('EDUMFA_AUDIT_KEY_PUBLIC')}"
     )
-    os.chmod(filename, 0o400)
-    click.echo(f"The file permission of {filename} was set to 400!")
     click.echo("Please ensure, that it is owned by the right user.")
 
 

--- a/edumfa/lib/caconnectors/localca.py
+++ b/edumfa/lib/caconnectors/localca.py
@@ -729,12 +729,10 @@ def _init_ca(config):
     f.close()
 
     # create the privacy key and set accesss rights
-    f = open("{0!s}/cakey.pem".format(config.directory), "w")
-    f.write("")
-    f.close()
-    import stat
+    descriptor = os.open(path=f"{config.directory}/cakey.pem", mode=0o600, flags=(os.O_WRONLY | os.O_CREAT))
+    with open(descriptor, "w") as f:
+        f.write("")
 
-    os.chmod("{0!s}/cakey.pem".format(config.directory), stat.S_IRUSR | stat.S_IWUSR)
     command = "openssl genrsa -out {0!s}/cakey.pem {1!s}".format(
         config.directory, config.keysize
     )


### PR DESCRIPTION
Sets the permission when creating the enkey, the audit keys, backups, full config backups and also the private key of the CA connector.
This could prevent an attacker racing to read the file before the permissions are set - especially the DB dump which is unprotected while the tar command is running (which could take a long time).  
In case of a full export with passwords, this could even mean that any user could read resolver passwords. 