### PR TITLE
fix: correct parsing username from dropdown with parentheses in givenName

### DIFF
--- a/edumfa/static/components/token/factories/token.js
+++ b/edumfa/static/components/token/factories/token.js
@@ -23,7 +23,7 @@
 function fixUser(user) {
     //debug: console.log("User In: " + user);
     if (user) {
-        var stripUser = user.match(/^\[.*\] (.*) \(.*\).*$/);
+        var stripUser = user.match(/^\[.*\] (.+?(?= \()) \(.*\).*$/);
         if (stripUser != undefined) {
             user = stripUser[1];
         }


### PR DESCRIPTION
If the givenName contains left parenthesis, the greedy `.*` will match too much. Instead do it lazily so it stops at the first.  