### PR TITLE
fix: prevent loading of inactive passkey

### DIFF
--- a/edumfa/lib/tokens/webauthntoken.py
+++ b/edumfa/lib/tokens/webauthntoken.py
@@ -1563,9 +1563,7 @@ class WebAuthnTokenClass(TokenClass):
             options["challenge"] = hexlify_and_unicode(challenge)
             if token.user.login is None or token.user.login == "":
                 log.warning(
-                    "Passkey {0!s} is assigned to a user without a login. Can not be used for authentication!".format(
-                        token.token.serial
-                    )
+                    f"Passkey {token.token.serial!s} is assigned to a user without a login. Can not be used for authentication!"
                 )
                 return False, {}
             try:

--- a/edumfa/lib/tokens/webauthntoken.py
+++ b/edumfa/lib/tokens/webauthntoken.py
@@ -1563,7 +1563,7 @@ class WebAuthnTokenClass(TokenClass):
             options["challenge"] = hexlify_and_unicode(challenge)
             if token.user.login is None or token.user.login == "":
                 log.warning(
-                    f"Passkey {token.token.serial!s} is assigned to a user without a login. Can not be used for authentication!"
+                    f"Passkey {token.token.serial} is assigned to a user without a login. Can not be used for authentication!"
                 )
                 return False, {}
             try:

--- a/edumfa/lib/tokens/webauthntoken.py
+++ b/edumfa/lib/tokens/webauthntoken.py
@@ -1561,6 +1561,13 @@ class WebAuthnTokenClass(TokenClass):
             )
             options["user"] = token.user
             options["challenge"] = hexlify_and_unicode(challenge)
+            if token.user.login is None or token.user.login == "":
+                log.warning(
+                    "Passkey {0!s} is assigned to a user without a login. Can not be used for authentication!".format(
+                        token.token.serial
+                    )
+                )
+                return False, {}
             try:
                 count = token.check_otp(otpval=None, options=options)
                 reply_dict["user"] = {


### PR DESCRIPTION
Right now it is possible to (partially) authenticate with a passkey of an inactive user. 
The response does not contain any user information and thus gets aborted by e.g. FUDIS but throws an error here.

This fix catches this corner case in eduMFA and aborts the authenication here.  