### PR TITLE
add bash completion support to ubuntu packages

### DIFF
--- a/deploy/ubuntu-server/edumfa-apache2.postinst
+++ b/deploy/ubuntu-server/edumfa-apache2.postinst
@@ -187,6 +187,10 @@ set_path() {
   ln -sf /opt/edumfa/bin/edumfa-token-janitor /usr/bin/
 }
 
+install_completions() {
+  _EDUMFA_MANAGE_COMPLETE=bash_source  edumfa-manage > /etc/bash_completion.d/edumfa-manage-prompt
+}
+
 case "$1" in
   configure)
     export PATH=$PATH:/opt/edumfa/bin
@@ -200,6 +204,7 @@ case "$1" in
     # Upgrade DB schema if upgradable.
     update_db
     set_path
+    install_completions
   ;;
   
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/deploy/ubuntu-server/edumfa-apache2.postrm
+++ b/deploy/ubuntu-server/edumfa-apache2.postrm
@@ -20,13 +20,16 @@ unset_sites () {
 
 unset_sites "$1"
 
-# Remove the symbolic link to edumfa-manage
+# Remove the symbolic links to the edumfa scripts
 if [ -L /usr/local/bin/edumfa-manage ]; then
   rm -f /usr/local/bin/edumfa-manage
   rm -f /usr/bin/edumfa-manage
   rm -f /usr/bin/edumfa-diag
   rm -f /usr/bin/edumfa-token-janitor
 fi
+
+# Remove bash completion
+rm -f /etc/bash_completion.d/edumfa-manage-prompt
 
 #DEBHELPER#
 exit 0

--- a/deploy/ubuntu-server/edumfa-nginx.postinst
+++ b/deploy/ubuntu-server/edumfa-nginx.postinst
@@ -185,10 +185,15 @@ set_path() {
   ln -sf /opt/edumfa/bin/edumfa-token-janitor /usr/bin/
 }
 
+install_completions() {
+  _EDUMFA_MANAGE_COMPLETE=bash_source  edumfa-manage > /etc/bash_completion.d/edumfa-manage-prompt
+}
+
 case "$1" in
   
   configure)
     set_path
+    install_completions
     create_user
     adapt_edumfa_cfg
     create_files

--- a/deploy/ubuntu-server/edumfa-nginx.postrm
+++ b/deploy/ubuntu-server/edumfa-nginx.postrm
@@ -18,13 +18,16 @@ unset_sites () {
 
 unset_sites
 
-# Remove the symbolic link to edumfa-manage
+# Remove the symbolic link to the edumfa scripts
 if [ -L /usr/local/bin/edumfa-manage ]; then
   rm -f /usr/local/bin/edumfa-manage
   rm -f /usr/bin/edumfa-manage
   rm -f /usr/bin/edumfa-diag
   rm -f /usr/bin/edumfa-token-janitor
 fi
+
+# Remove bash completion
+rm -f /etc/bash_completion.d/edumfa-manage-prompt
 
 #DEBHELPER#
 exit 0

--- a/edumfa/app.py
+++ b/edumfa/app.py
@@ -119,13 +119,16 @@ def create_app(
     :return: The flask application
     :rtype: App object
     """
+    app = Flask(__name__, static_folder="static", template_folder="static/templates")
+    if config_name == "completion":
+        return app
+
     if not silent:
         print(f"The configuration name is: {config_name}")
     if os.environ.get(ENV_KEY):
         config_file = os.environ[ENV_KEY]
     if not silent:
         print(f"Additional configuration will be read from the file {config_file}")
-    app = Flask(__name__, static_folder="static", template_folder="static/templates")
     if config_name:
         app.config.from_object(config[config_name])
 

--- a/edumfa/commands/manage/main.py
+++ b/edumfa/commands/manage/main.py
@@ -17,6 +17,8 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import os
+
 import click
 from flask.cli import FlaskGroup, run_command
 
@@ -48,13 +50,16 @@ from edumfa.lib.utils import get_version_number
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
-def create_prod_app():
-    return create_app("production", silent=True)
+def _create_app():
+    if not os.getenv("_EDUMFA_MANAGE_COMPLETE"):
+        return create_app("production", silent=True)
+    else:
+        return create_app("completion")
 
 
 @click.group(
     cls=FlaskGroup,
-    create_app=create_prod_app,
+    create_app=_create_app,
     context_settings=CONTEXT_SETTINGS,
     epilog="Check out our docs at https://edumfa.readthedocs.io/ for more details",
 )


### PR DESCRIPTION
Adds simple bash completion to the Ubuntu packages. Drafted because:  
- slow: around 1s per completion
- tab has to be pressed twice?
- TODO protobuf has to be installed
- TODO test .deb with 2.9.0 release
- TODO testing of all of the sub-commands

Theoretically it could at some point quite easily also auto-complete e.g. policy names. The problem is that the user in question would have to have read access to the config file, which is likely only the case as root or the edumfa user.