### PR TITLE
feat: add option for token-janitor to remove tokeninfo

### DIFF
--- a/doc/workflows_and_tools/tools/index.rst
+++ b/doc/workflows_and_tools/tools/index.rst
@@ -292,6 +292,20 @@ A new tokeninfo-key and the associated tokeninfo-value would be added for the to
 and are now marked for later processing. If the token already containd this tokeninf-key, the value
 would be changed.
 
+unmark
+....
+
+**Unmark** makes it possible to remove former added marks from tokens.
+
+Tokens can be unmarked by removing a tokeninfo-key and the associated value.
+
+Example::
+
+    edumfa-token-janitor find --serial OATH0004C934 --action unmark --remove-tokeninfo-key unused
+
+If the given tokeninfo-key is present on the specified token then this key with its values is removed.
+Otherwise nothing happens.
+
 
 disable
 .......

--- a/doc/workflows_and_tools/tools/index.rst
+++ b/doc/workflows_and_tools/tools/index.rst
@@ -282,14 +282,14 @@ mark
 
 **Mark** makes it possible to mark the found tokens in order to carry out further actions with them later.
 
-The tokens are marked by setting a tokeninfo-key and an associated tokininfo-value.
+The tokens are marked by setting a tokeninfo-key and an associated tokeninfo-value.
 
 Example::
 
     edumfa-token-janitor find --serial OATH0004C934 --action mark --set-tokeninfo-key unused --set-tokeninfo-value True
 
 A new tokeninfo-key and the associated tokeninfo-value would be added for the token ``OAUTH0004C934``
-and are now marked for later processing. If the token already containd this tokeninf-key, the value
+and are now marked for later processing. If the token already contained this tokeninfo-key, the value
 would be changed.
 
 unmark

--- a/tools/edumfa-token-janitor
+++ b/tools/edumfa-token-janitor
@@ -815,13 +815,18 @@ def find(
                                 token_obj.save()
                         elif action == "unmark":
                             if remove_tokeninfo_key:
-                                click.echo(
-                                    f"Removing tokeninfo for token {token_obj.token.serial!s}: {remove_tokeninfo_key!s}"
-                                )
-                                token_obj.del_tokeninfo(
-                                    remove_tokeninfo_key
-                                )
-                                token_obj.save()
+                                if not token_obj.get_tokeninfo(key=remove_tokeninfo_key):
+                                    click.echo(
+                                        f"Could not find tokeninfo-key {remove_tokeninfo_key!s} on token {token_obj.token.serial!s}"
+                                    )
+                                else:
+                                    click.echo(
+                                        f"Removing tokeninfo for token {token_obj.token.serial!s}: {remove_tokeninfo_key!s}"
+                                    )
+                                    token_obj.del_tokeninfo(
+                                        remove_tokeninfo_key
+                                    )
+                                    token_obj.save()
                     except Exception as exx:
                         click.echo(f"Failed to process token {token_obj.token.serial}.")
                         click.echo("{0}".format(exx))

--- a/tools/edumfa-token-janitor
+++ b/tools/edumfa-token-janitor
@@ -67,6 +67,7 @@ ALLOWED_ACTIONS = [
     "delete",
     "unassign",
     "mark",
+    "unmark",
     "export",
     "listuser",
     "tokenrealms",
@@ -485,6 +486,7 @@ def export_user_data(token_list, attributes=None):
 @click.option("--set-description", help="set a new description")
 @click.option("--set-tokeninfo-key", help="set a new tokeninfo-key")
 @click.option("--set-tokeninfo-value", help="set a new tokeninfo-value")
+@click.option("--remove-tokeninfo-key", help="remove a tokeninfo-key (and values)")
 @click.option(
     "--tokeninfo-value-before",
     metavar="DATETIME",
@@ -625,6 +627,7 @@ def find(
     set_description,
     set_tokeninfo_key,
     set_tokeninfo_value,
+    remove_tokeninfo_key,
     sum_tokens,
     tokenrealms,
     csv,
@@ -808,6 +811,15 @@ def find(
                                 )
                                 token_obj.add_tokeninfo(
                                     set_tokeninfo_key, set_tokeninfo_value
+                                )
+                                token_obj.save()
+                        elif action == "unmark":
+                            if remove_tokeninfo_key:
+                                click.echo(
+                                    f"Removing tokeninfo for token {token_obj.token.serial!s}: {remove_tokeninfo_key!s}"
+                                )
+                                token_obj.del_tokeninfo(
+                                    remove_tokeninfo_key
                                 )
                                 token_obj.save()
                     except Exception as exx:

--- a/tools/edumfa-token-janitor
+++ b/tools/edumfa-token-janitor
@@ -91,6 +91,7 @@ Actions:
 * list
 * unassign
 * mark
+* unmark
 * disable
 * delete
 


### PR DESCRIPTION
This adds the possibility to remove a former set tokeninfo-attribute to the token-janitor.