### PR TITLE
fix: correct undeletable token and janitor orphan search for `PasswdIdResolver`

### DIFF
--- a/edumfa/lib/resolvers/PasswdIdResolver.py
+++ b/edumfa/lib/resolvers/PasswdIdResolver.py
@@ -247,17 +247,20 @@ class IdResolver(UserIdResolver):
 
         return ret
 
-    def getUsername(self, userId):
+    def getUsername(self, userId: str) -> str:
         """
-        Returns the username/loginname for a given userid
-        :param userid: The userid in this resolver
-        :type userid: string
-        :return: username
-        :rtype: str
+        Returns the username/loginname for a given userid, or an empty string
+        if it can't be found.
+
+        :param userid: the userid of the user in this resolver
+        :return: username/loginname of the userid
         """
         fields = self.descDict.get(userId)
-        index = self.sF["username"]
-        return fields[index]
+        if not fields:
+            return ""
+        else:
+            index = self.sF["username"]
+            return fields[index]
 
     def getUserId(self, LoginName):
         """

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -260,6 +260,9 @@ class SQLResolverTestCase(MyTestCase):
         username = y.getUsername(user_id)
         self.assertEqual(username, "cornelius", username)
 
+        username = y.getUsername("user does not exist")
+        self.assertEqual(username, "")
+
     def test_01a_where_tests(self):
         y = SQLResolver()
         d = self.parameters.copy()
@@ -1091,6 +1094,9 @@ class LDAPResolverTestCase(MyTestCase):
 
         username = y.getUsername(user_id)
         self.assertTrue(username == "bob", username)
+
+        username = y.getUsername("user does not exist")
+        self.assertEqual(username, "")
 
         pw = "bobpwééé"
         res = y.checkPass(user_id, pw)
@@ -2637,7 +2643,7 @@ class BaseResolverTestCase(MyTestCase):
         self.assertEqual(r[1], "Not implemented")
 
 
-class ResolverTestCase(MyTestCase):
+class PasswdIdResolverTestCase(MyTestCase):
     """
     Test the Passwdresolver
     """

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -2864,6 +2864,7 @@ class ResolverTestCase(MyTestCase):
         self.assertFalse(y.checkPass("1002", "no pw at all"))
         self.assertTrue(y.getUsername("1000") == "cornelius", y.getUsername("1000"))
         self.assertTrue(y.getUserId("cornelius") == "1000", y.getUserId("cornelius"))
+        self.assertEqual(y.getUsername("user does not exist"), "")
         self.assertTrue(y.getUserId("user does not exist") == "")
         # Check that non-ASCII user was read successfully
         self.assertEqual(y.getUsername("1116"), "nönäscii")

--- a/tools/edumfa-token-janitor
+++ b/tools/edumfa-token-janitor
@@ -119,13 +119,6 @@ Actions:
         --set-tokeninfo-value=<value>    
         --limit=<value>
     
-.. note:: If you fail to redirect the output of this command at the commandline
-   to e.g. a file with a UnicodeEncodeError, you need to set the environment
-   variable like this:
-       export PYTHONIOENCODING=UTF-8
-   Here is a good read about it:
-   https://stackoverflow.com/questions/4545661/unicodedecodeerror-when-redirecting-to-file
-
 """
 
 import click
@@ -545,7 +538,7 @@ def export_user_data(token_list, attributes=None):
 )
 @click.option(
     "--tokenrealms",
-    help="A comma separated list of realms, to which the tokens should be assigned.",
+    help="A comma separated list of realms to which the tokens should be assigned.",
 )
 @click.option(
     "--sum",
@@ -558,7 +551,7 @@ def export_user_data(token_list, attributes=None):
 @click.option(
     "--action",
     help=f"Which action should be performed on the "
-    f"found tokens. {'|'.join(ALLOWED_ACTIONS)}. Exporting to PSKC only supports "
+    f"found tokens: {'|'.join(ALLOWED_ACTIONS)}. Exporting to PSKC only supports "
     f"HOTP, TOTP and PW tokens!",
 )
 @click.option(
@@ -574,14 +567,17 @@ def export_user_data(token_list, attributes=None):
     "formatted output.",
 )
 @click.option("--last_auth", help="Can be something like 10h, 7d, or 2y")
-@click.option("--assigned", help="True|False|None")
-@click.option("--active", help="True|False|None")
-@click.option("--orphaned", help="Whether the token is an orphaned token. Set to 1")
+@click.option("--assigned", help="True|False|None (default)")
+@click.option("--active", help="True|False|None (default)")
+@click.option(
+    "--orphaned",
+    help="Whether the token is an orphaned token (True|False|None (default)).",
+)
 @click.option(
     "--orphan_exception_value",
     default=False,
     type=bool,
-    help="If an exception occures during orphan check use this value.",
+    help="Whether to consider users whose lookup causes an exception as orphaned (True|False (default)|None).",
 )
 @click.option(
     "--b32",


### PR DESCRIPTION
Currently it throws an Exception "'NoneType' object is not subscriptable". This makes deleting orphaned tokens of PasswdIdResolver in the webui impossible. Also they don't show up in the token janitor's orphan search.  

Also removes the notice about Python2 encoding difficulties as its not relevant for Python3.