### PR TITLE
fix: correct & optimize database stamping and migrations in docker setup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,12 +104,6 @@ Then create the database tables and the encryption key::
     ./edumfa-manage create_tables
     ./edumfa-manage create_enckey
 
-If You want to keep the development database upgradable, You should `stamp
-<https://edumfa.readthedocs.io/en/latest/installation/upgrade.html>`_ it
-to simplify updates::
-
-    ./edumfa-manage db stamp head -d migrations/
-
 Create the key for the audit log::
 
     ./edumfa-manage create_audit_keys

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -23,20 +23,8 @@ edumfa-manage -q create_audit_keys || true
 # Wait for DB to be available
 edumfa-manage -q wait_for_db || exit 1
 
-# Check for an existing stamp -> if none exists, we have to create tables first
-# Create tables will create new tables even if there is already a database -> might break migrations that try to do this actions on their own!
-STAMP=$(edumfa-manage -q db current -d /usr/local/lib/edumfa/migrations) || true
-# Remove "Running online" from stamp for cleaner output
-STAMP=${STAMP//Running online/}
-# Remove leading and trailing whitespace and linebreaks
-STAMP=$(echo "$STAMP" | xargs)
-if [[ -z "${STAMP}" ]]; then
-  echo "No existing database stamp found."
-  echo "Initializing database and creating tables."
-  edumfa-manage -q create_tables --stamp
-else
-  echo "Existing database stamp found: $STAMP. Skipping database/table creation."
-fi
+# Create DB tables if the DB is unstamped.
+edumfa-manage -q create_tables
 
 # Upgrading DB
 echo "Upgrading Database"

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -20,26 +20,22 @@ edumfa-manage -q create_enckey || true
 # Create audit keys if they don't exist yet
 edumfa-manage -q create_audit_keys || true
 
-# Create DB
-echo "Creating DB"
-# FIXME: this creates a exception trace on every attempt
-attempts=10
-until edumfa-manage -q create_tables 
-do
-  if [[ $attempts -eq 0 ]]; then
-    echo "Exhausted database connection tries. Stopping."
-    exit 1
-  else
-    echo "Cannot connect to database. Trying again..."
-    sleep 3
-    attempts=$((attempts-1))
-  fi
-done
+# Wait for DB to be available
+edumfa-manage -q wait_for_db || exit 1
 
-# Check and stamp DB
-STAMP=$(edumfa-manage -q db current -d /usr/local/lib/edumfa/migrations)
-if [[ -z "${STAMP//Running online/}" ]]; then
-  edumfa-manage -q db stamp head -d /usr/local/lib/edumfa/migrations
+# Check for an existing stamp -> if none exists, we have to create tables first
+# Create tables will create new tables even if there is already a database -> might break migrations that try to do this actions on their own!
+STAMP=$(edumfa-manage -q db current -d /usr/local/lib/edumfa/migrations) || true
+# Remove "Running online" from stamp for cleaner output
+STAMP=${STAMP//Running online/}
+# Remove leading and trailing whitespace and linebreaks
+STAMP=$(echo "$STAMP" | xargs)
+if [[ -z "${STAMP}" ]]; then
+  echo "No existing database stamp found."
+  echo "Initializing database and creating tables."
+  edumfa-manage -q create_tables --stamp
+else
+  echo "Existing database stamp found: $STAMP. Skipping database/table creation."
 fi
 
 # Upgrading DB

--- a/deploy/ubuntu-server/edumfa-apache2.postinst
+++ b/deploy/ubuntu-server/edumfa-apache2.postinst
@@ -17,7 +17,6 @@ CERTDAYS=1095
 CERTKEYSIZE=4096
 MIGRATIONSDIR=/opt/edumfa/lib/edumfa/migrations/
 MYSQLFIX=/etc/mysql/conf.d/edumfa-maxkeylengthfix.cnf
-DB_CREATED=false
 CONFIG_FILE=/etc/edumfa/edumfa.cfg
 
 # Default paths
@@ -159,8 +158,7 @@ create_database() {
     mysql -u "$USER" --password="$PASSWORD" -e "grant all privileges on edumfa.* to 'edumfa'@'localhost';"
     echo "SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://edumfa:$NPW@localhost/edumfa?charset=utf8mb4'" >> /etc/edumfa/edumfa.cfg
     echo "DB created"
-    /opt/edumfa/bin/edumfa-manage create_tables || true
-    DB_CREATED=true
+    /opt/edumfa/bin/edumfa-manage create_tables
   fi
 }
 
@@ -179,7 +177,7 @@ enable_apache() {
 
 update_db() {
   # Upgrade the database
-  /opt/edumfa/bin/edumfa-schema-upgrade $MIGRATIONSDIR
+  /opt/edumfa/bin/edumfa-schema-upgrade "$MIGRATIONSDIR" --skipstamp
 }
 
 set_path() {
@@ -198,17 +196,9 @@ case "$1" in
     create_database
     enable_apache
     create_certificate
-    #update-rc.d apache2 defaults
     service apache2 restart
-    if [ "$DB_CREATED" = true ]; then
-      # We've created the DB, so we stamp the DB
-      touch /tmp/edumfa-install
-      /opt/edumfa/bin/edumfa-manage db stamp -d $MIGRATIONSDIR head
-    else
-      # The DB was already created, so a update might be necessary
-      touch /tmp/edumfa-upgrade
-      update_db
-    fi
+    # Upgrade DB schema if upgradable.
+    update_db
     set_path
   ;;
   

--- a/deploy/ubuntu-server/edumfa-nginx.postinst
+++ b/deploy/ubuntu-server/edumfa-nginx.postinst
@@ -16,7 +16,6 @@ CERTDAYS=1095
 CERTKEYSIZE=4096
 MIGRATIONSDIR=/opt/edumfa/lib/edumfa/migrations/
 MYSQLFIX=/etc/mysql/conf.d/edumfa-maxkeylengthfix.cnf
-DB_CREATED=false
 CONFIG_FILE=/etc/edumfa/edumfa.cfg
 
 # Default paths
@@ -160,8 +159,7 @@ create_database() {
     mysql -u "$USER" --password="$PASSWORD" -e "grant all privileges on edumfa.* to 'edumfa'@'localhost';"
     echo "SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://edumfa:$NPW@localhost/edumfa?charset=utf8mb4'" >> /etc/edumfa/edumfa.cfg
     echo "DB created"
-    /opt/edumfa/bin/edumfa-manage create_tables || true
-    DB_CREATED=true
+    /opt/edumfa/bin/edumfa-manage create_tables
   fi
 }
 
@@ -177,7 +175,7 @@ enable_nginx_uwsgi() {
 
 update_db() {
   # Upgrade the database
-  /opt/edumfa/bin/edumfa-schema-upgrade $MIGRATIONSDIR
+  /opt/edumfa/bin/edumfa-schema-upgrade $MIGRATIONSDIR --skipstamp
 }
 
 set_path() {
@@ -197,15 +195,8 @@ case "$1" in
     create_database
     enable_nginx_uwsgi
     create_certificate
-    if [ "$DB_CREATED" = true ]; then
-      # We've created the DB, so we stamp the DB
-      /opt/edumfa/bin/edumfa-manage db stamp -d $MIGRATIONSDIR head
-    else
-      # The DB was already created, so a update might be necessary
-      update_db
-    fi
-    #update-rc.d nginx defaults
-    #update-rc.d uwsgi defaults
+    # Upgrade DB schema if upgradable.
+    update_db
     service uwsgi restart
     service nginx restart
   ;;

--- a/doc/installation/pip.rst
+++ b/doc/installation/pip.rst
@@ -92,11 +92,6 @@ To create the database tables execute::
 
     edumfa-manage create_tables
 
-Stamping the database to the current database schema version is important for
-the update process later::
-
-    edumfa-manage db stamp head -d /opt/edumfa/lib/edumfa/migrations/
-
 After creating a local administrative user with::
 
     edumfa-manage admin add <login>

--- a/edumfa/commands/manage/core.py
+++ b/edumfa/commands/manage/core.py
@@ -204,8 +204,7 @@ def create_tables():
     doing anything (with a successful exit code).
     """
     click.echo(db)
-    with db.engine.connect() as connection:
-        database_is_stamped = is_db_stamped(connection)
+    database_is_stamped = is_db_stamped(db.engine)
     if not database_is_stamped:
         db.create_all()
         # stamp the database
@@ -222,7 +221,7 @@ def create_tables():
         click.echo(
             "Your database seems to already have been created. To upgrade its schema, please see the documentation."
         )
-        # For backwards compat, exit successfully if nothing was done.
+        # Exit successfully if nothing was done.
         sys.exit(0)
 
 

--- a/edumfa/commands/manage/main.py
+++ b/edumfa/commands/manage/main.py
@@ -35,6 +35,7 @@ from edumfa.commands.manage.core import (
     create_tables,
     drop_tables,
     encrypt_enckey,
+    wait_for_db,
 )
 from edumfa.commands.manage.event import event_cli
 from edumfa.commands.manage.hsm import hsm_cli
@@ -93,6 +94,7 @@ cli.add_command(encrypt_enckey)
 cli.add_command(create_audit_keys)
 cli.add_command(create_tables)
 cli.add_command(create_tables, "createdb")
+cli.add_command(wait_for_db)
 cli.add_command(create_pgp_keys)
 cli.add_command(drop_tables)
 cli.add_command(drop_tables, "dropdb")


### PR DESCRIPTION
As described in #983 from my point of view the current docker entrypoint has a little painpoint.

This PR adds a new cli command to wait for the database (yeah ... I use `select 1`) and revises the flow a bit.

In the new version the following outputs will be generated:

## First Run

```
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | The file '/etc/edumfa/enckey' already exists.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | The file '/etc/edumfa/private.pem' already exists.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | Failed to connect to database. Attempt 1 of 5. Waiting 5 seconds...
edumfa-1  | Failed to connect to database. Attempt 2 of 5. Waiting 5 seconds...
edumfa-1  | Database connection successful.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
edumfa-1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
edumfa-1  | No existing database stamp found.
edumfa-1  | Initializing database and creating tables.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | <SQLAlchemy mysql+pymysql://edumfa:***@mariadb/edumfa?charset=utf8mb4>
edumfa-1  | Running online
edumfa-1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
edumfa-1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
edumfa-1  | INFO  [alembic.runtime.migration] Running stamp_revision  -> 2a74c6522937
edumfa-1  | Upgrading Database
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
edumfa-1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
edumfa-1  | ++ Upgrading DB schema.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | Running online
edumfa-1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
edumfa-1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
edumfa-1  | Creating Admin
```

## Additional run without migration

```
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | The file '/etc/edumfa/enckey' already exists.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | The file '/etc/edumfa/private.pem' already exists.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | Database connection successful.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
edumfa-1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
edumfa-1  | Existing database stamp found: 2a74c6522937 (head). Skipping database/table creation.
edumfa-1  | Upgrading Database
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
edumfa-1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
edumfa-1  | ++ Upgrading DB schema.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | Running online
edumfa-1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
edumfa-1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
edumfa-1  | Creating Admin
```

## Additional run with migration

```
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | The file '/etc/edumfa/enckey' already exists.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | The file '/etc/edumfa/private.pem' already exists.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | Database connection successful.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
edumfa-1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
edumfa-1  | Existing database stamp found: 2a74c6522937. Skipping database/table creation.
edumfa-1  | Upgrading Database
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
edumfa-1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
edumfa-1  | ++ Upgrading DB schema.
edumfa-1  | Can not import grpc modules - No module named 'google.protobuf'
edumfa-1  | Running online
edumfa-1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
edumfa-1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
edumfa-1  | INFO  [alembic.runtime.migration] Running upgrade 2a74c6522937 -> 2bed9a05c8d7, empty message
edumfa-1  | Creating Admin
```