### PR TITLE
ci: publish artifacts on git tag instead of github release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,8 @@ permissions:
 on:
   push:
     branches: [ main ]
+    tags:
+      - 'v*'
     paths:
       - '.github/workflows/docker.yml'
       - 'deploy/docker/**'
@@ -19,8 +21,6 @@ on:
       - 'setup.py'
   pull_request:
     types: [ opened, reopened, synchronize ]
-  release:
-    types: [ published ]
 
 jobs:
   docker:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,9 @@ permissions:
   contents: read
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,6 +6,8 @@ permissions:
 on:
   push:
     branches: [ main ]
+    tags:
+      - 'v*'
     paths:
       - '.github/workflows/ubuntu.yml'
       - 'deploy/ubuntu*/**'
@@ -17,8 +19,6 @@ on:
       - 'setup.py'
   pull_request:
     types: [ opened, reopened, synchronize ]
-  release:
-    types: [ released ]
 
 jobs:
   build:
@@ -59,7 +59,7 @@ jobs:
           dpkg-buildpackage -us -uc -b
           rm -r debian
       - name: Upload packages to Nexus
-        if: github.event_name == 'release'
+        if: github.ref_type == 'tag'
         env:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}


### PR DESCRIPTION
This PR prepares the ci for our new release flow. Instead of publishing a GitHub release, we just tag the changes.