### PR TITLE
feat(image): use hostname as node name

### DIFF
--- a/deploy/docker/edumfa.py
+++ b/deploy/docker/edumfa.py
@@ -1,4 +1,5 @@
 from os import getenv
+from socket import gethostname
 
 
 def get_content_from_file(path: str) -> str:
@@ -61,3 +62,4 @@ EDUMFA_LOGFILE = "/var/log/edumfa/edumfa.log"
 EDUMFA_LOGCONFIG = "/etc/edumfa/logging.yml"
 EDUMFA_UI_DEACTIVATED = get_var("EDUMFA_UI_DEACTIVATED", "False") == "True"
 EDUMFA_AUDIT_SQL_TRUNCATE = True
+EDUMFA_NODE = gethostname()


### PR DESCRIPTION
Currently, audit log entries from different containers can't be differentiated. Therefore instead use the hostname as a eduMFA Node identifier. On Docker, this would generally be the container ID and on [Kubernetes](https://kubernetes.io/docs/concepts/workloads/pods/pod-hostname/#default-pod-hostname) the name of the pod. If users want a different identifier, they can override the hostname of the container.

Audit log entry currently with our images:
<img width="160" height="123" alt="grafik" src="https://github.com/user-attachments/assets/61fa2cd4-fb33-4e92-94a5-9fc18cafa113" />

With this change on docker:
<img width="159" height="270" alt="grafik" src="https://github.com/user-attachments/assets/3c6c45d1-971d-4730-b4cc-e94b8b3cb2a2" />