### PR TITLE
chore(deps): update dependency ldap3 to v2.10.2rc3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ jinja2==3.1.6
     # via
     #   flask
     #   flask-babel
-ldap3==2.9.1
+ldap3==2.10.2rc3
     # via edumfa (setup.py)
 lxml==6.0.2
     # via


### PR DESCRIPTION
There are no releases, but the last commit introduced a RC which we can use.  Upgrading to fix https://github.com/cannatag/ldap3/pull/1171.  
Tested login, editing and listing users.