### PR TITLE
chore: replace pytz with standard library zoneinfo

### DIFF
--- a/edumfa/lib/tokens/pushtoken.py
+++ b/edumfa/lib/tokens/pushtoken.py
@@ -32,7 +32,7 @@ import time
 import traceback
 from base64 import b32decode
 from binascii import Error as BinasciiError
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import quote
 
 from cryptography.exceptions import InvalidSignature
@@ -41,7 +41,6 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, padding
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 from dateutil.parser import isoparse
-from pytz import utc
 
 from edumfa.api.lib.policyhelper import get_pushtoken_add_config
 from edumfa.api.lib.utils import getParam
@@ -780,7 +779,7 @@ class PushTokenClass(TokenClass):
         # We don't know if the passed timestamp is timezone aware. If no
         # timezone is passed, we assume UTC
         if ts.tzinfo:
-            now = datetime.now(utc)
+            now = datetime.now(timezone.utc)
         else:
             now = datetime.utcnow()
         if not (now - td <= ts <= now + td):

--- a/tests/test_api_ttype.py
+++ b/tests/test_api_ttype.py
@@ -7,7 +7,6 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from google.oauth2 import service_account
-from pytz import utc
 
 from edumfa.lib.config import set_edumfa_config
 from edumfa.lib.policy import SCOPE, delete_policy, set_policy

--- a/tests/test_lib_tokens_push.py
+++ b/tests/test_lib_tokens_push.py
@@ -1,7 +1,7 @@
 import json
 import time
 from base64 import b32decode, b32encode
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from threading import Timer
 from unittest import mock
 
@@ -13,7 +13,6 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPubl
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 from flask import Request
 from google.oauth2 import service_account
-from pytz import utc
 from werkzeug.test import EnvironBuilder
 
 from edumfa.lib.challenge import get_challenges
@@ -1200,7 +1199,7 @@ class PushTokenTestCase(MyTestCase):
             timestamp_fmt,
             10,
         )
-        timestamp = datetime(2020, 11, 13, 13, 27, tzinfo=utc)
+        timestamp = datetime(2020, 11, 13, 13, 27, tzinfo=timezone.utc)
         with mock.patch("edumfa.lib.tokens.pushtoken.datetime") as mock_dt:
             mock_dt.now.return_value = timestamp + timedelta(minutes=9)
             LegacyPushTokenClass._check_timestamp_in_range(timestamp.isoformat(), 10)
@@ -1289,7 +1288,7 @@ class PushTokenTestCase(MyTestCase):
         req = Request(builder.get_environ())
         req.all_data = {
             "serial": "SPASS01",
-            "timestamp": (datetime.now(utc) - timedelta(minutes=2)).isoformat(),
+            "timestamp": (datetime.now(timezone.utc) - timedelta(minutes=2)).isoformat(),
             "signature": "unknown",
         }
         self.assertRaisesRegex(
@@ -1304,7 +1303,7 @@ class PushTokenTestCase(MyTestCase):
         req = Request(builder.get_environ())
         req.all_data = {
             "serial": "SPASS01",
-            "timestamp": (datetime.now(utc) + timedelta(minutes=2)).isoformat(),
+            "timestamp": (datetime.now(timezone.utc) + timedelta(minutes=2)).isoformat(),
             "signature": "unknown",
         }
         self.assertRaisesRegex(
@@ -1405,7 +1404,7 @@ class PushTokenTestCase(MyTestCase):
         req_data = {
             "new_fb_token": "firebasetoken2",
             "serial": serial,
-            "timestamp": datetime.now(tz=utc).isoformat(),
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         }
 
         # now we perform the firebase token update with a broken signature
@@ -1465,7 +1464,7 @@ class PushTokenTestCase(MyTestCase):
         serial = tok.get_serial()
 
         # this is the default timestamp for polling in this test
-        timestamp = datetime(2020, 6, 19, 13, 27, tzinfo=utc)
+        timestamp = datetime(2020, 6, 19, 13, 27, tzinfo=timezone.utc)
 
         # create a poll request
         # first create a signature
@@ -2917,7 +2916,7 @@ class EduPushTokenTestCase(MyTestCase):
             timestamp_fmt,
             10,
         )
-        timestamp = datetime(2020, 11, 13, 13, 27, tzinfo=utc)
+        timestamp = datetime(2020, 11, 13, 13, 27, tzinfo=timezone.utc)
         with mock.patch("edumfa.lib.tokens.pushtoken.datetime") as mock_dt:
             mock_dt.now.return_value = timestamp + timedelta(minutes=9)
             PushTokenClass._check_timestamp_in_range(timestamp.isoformat(), 10)
@@ -3002,7 +3001,7 @@ class EduPushTokenTestCase(MyTestCase):
         req = Request(builder.get_environ())
         req.all_data = {
             "serial": "SPASS01",
-            "timestamp": (datetime.now(utc) - timedelta(minutes=2)).isoformat(),
+            "timestamp": (datetime.now(timezone.utc) - timedelta(minutes=2)).isoformat(),
             "signature": "unknown",
         }
         self.assertRaisesRegex(
@@ -3017,7 +3016,7 @@ class EduPushTokenTestCase(MyTestCase):
         req = Request(builder.get_environ())
         req.all_data = {
             "serial": "SPASS01",
-            "timestamp": (datetime.now(utc) + timedelta(minutes=2)).isoformat(),
+            "timestamp": (datetime.now(timezone.utc) + timedelta(minutes=2)).isoformat(),
             "signature": "unknown",
         }
         self.assertRaisesRegex(
@@ -3118,7 +3117,7 @@ class EduPushTokenTestCase(MyTestCase):
         req_data = {
             "new_fb_token": "firebasetoken2",
             "serial": serial,
-            "timestamp": datetime.now(tz=utc).isoformat(),
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         }
 
         # now we perform the firebase token update with a broken signature
@@ -3178,7 +3177,7 @@ class EduPushTokenTestCase(MyTestCase):
         serial = tok.get_serial()
 
         # this is the default timestamp for polling in this test
-        timestamp = datetime(2020, 6, 19, 13, 27, tzinfo=utc)
+        timestamp = datetime(2020, 6, 19, 13, 27, tzinfo=timezone.utc)
 
         # create a poll request
         # first create a signature


### PR DESCRIPTION
Standard lib also provides a utc timezone object, so we don't need pytz here. 

This is in preperation to remove pytz as a direct dependency in #998