### PR TITLE
feat: add missing functionality to enable tokens again

### DIFF
--- a/tools/edumfa-token-janitor
+++ b/tools/edumfa-token-janitor
@@ -70,6 +70,7 @@ ALLOWED_ACTIONS = [
     "export",
     "listuser",
     "tokenrealms",
+    "enable",
 ]
 
 __doc__ = f"""
@@ -93,6 +94,7 @@ Actions:
 * unmark
 * disable
 * delete
+* enable
 
 
     edumfa-token-janitor find
@@ -778,6 +780,9 @@ def find(
                         if action == "disable":
                             enable_token(serial=token_obj.token.serial, enable=False)
                             click.echo(f"Disabling token {token_obj.token.serial}")
+                        elif action == "enable":
+                            enable_token(serial=token_obj.token.serial, enable=True)
+                            click.echo(f"Enabling token {token_obj.token.serial}")
                         elif action == "delete":
                             remove_token(serial=token_obj.token.serial)
                             click.echo(f"Deleting token {token_obj.token.serial}")

--- a/tools/edumfa-token-janitor
+++ b/tools/edumfa-token-janitor
@@ -76,7 +76,7 @@ ALLOWED_ACTIONS = [
 __doc__ = f"""
 This script can be used to clean up the token database.
 
-It can list, disable, delete or mark tokens based on
+It can list, disable, enable, delete or mark tokens based on
 
 Conditions:
 


### PR DESCRIPTION
This pull request adds support for an `enable` action to the `edumfa-token-janitor` tool, making it possible to enable previously disabled tokens. The new action is integrated alongside the existing actions and is reflected in both the allowed actions list and the user documentation.

New token action support:

* Added `"enable"` to the `ALLOWED_ACTIONS` list in `tools/edumfa-token-janitor`, allowing the tool to recognize and process the new action.
* Updated the documentation and help text to include the `enable` action in the list of available actions.
* Implemented the logic for the `enable` action in the `find` function, calling `enable_token` with `enable=True` and providing user feedback when a token is enabled.