### PR TITLE
fix(webui): token wizard silently ignoring default tokentype

### DIFF
--- a/edumfa/static/components/token/controllers/tokenControllers.js
+++ b/edumfa/static/components/token/controllers/tokenControllers.js
@@ -424,6 +424,17 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
                 $scope.changeTokenType();
                 break;
             }
+            // Warn about a default tokentype being set which the user can't
+            // enroll. "hotp" is the default value when no default_tokentype is
+            // set. If the default_tokentype is hotp, it could either be due to
+            // default_tokentype not being set at all or to "hotp". As setting
+            // default_tokentype is technically not required for the token
+            // wizard, don't emit a warning to not surprise existing
+            // configurations.
+            if ($scope.default_tokentype != "hotp") {
+                inform.add(`Your user has no permission to enroll the default tokentype '${$scope.default_tokentype}'. Using '${tkey}' instead.`,
+                    {type: "warning", ttl: 10000});
+            }
         }
     });
 


### PR DESCRIPTION
Currently, when a user has no permission to enroll the default tokentype, the UI presents the first enrollable type instead. This PR adds a warning so administrators can at least know why this is happening.  
This warning would not show if there is no default tokentype set, as this would suddenly make a warning appear on existing configurations since a default_tokentype is technically not required for the token wizard.  

<img width="1247" height="382" alt="grafik" src="https://github.com/user-attachments/assets/05ab97d6-91a7-461d-854b-6481fb7af7cd" />
