### PR TITLE
feat(image): Allow customization options to be set using env variables

### DIFF
--- a/deploy/docker/edumfa.py
+++ b/deploy/docker/edumfa.py
@@ -26,7 +26,7 @@ def _getenv(key: str, default: str | None) -> str:
         value.
     """
     value = getenv(key, default)
-    if not value:
+    if value is None:
         raise ValueError(f"Environment variable '{key}' not set! Can't start...")
     else:
         return value
@@ -63,3 +63,9 @@ EDUMFA_LOGCONFIG = "/etc/edumfa/logging.yml"
 EDUMFA_UI_DEACTIVATED = get_var("EDUMFA_UI_DEACTIVATED", "False") == "True"
 EDUMFA_AUDIT_SQL_TRUNCATE = True
 EDUMFA_NODE = gethostname()
+if edumfa_logo := get_var("EDUMFA_LOGO", ""):
+    EDUMFA_LOGO = edumfa_logo
+if edumfa_page_title := getenv("EDUMFA_PAGE_TITLE", ""):
+    EDUMFA_PAGE_TITLE = edumfa_page_title
+if edumfa_css := getenv("EDUMFA_CSS", ""):
+    EDUMFA_CSS = edumfa_css

--- a/doc/installation/docker.rst
+++ b/doc/installation/docker.rst
@@ -82,6 +82,9 @@ The `.env` file should contain the following variables:
 - EDUMFA_ADMIN_PASS: the password for the local eduMFA admin (optional)
 - SUPERUSER_REALM: which realms should be superuser realms (optional)
 - EDUMFA_UI_DEACTIVATED: whether to disable the WebUI (optional)
+- EDUMFA_LOGO: filename of custom logo (optional)
+- EDUMFA_PAGE_TITLE: custom page title (optional)
+- EDUMFA_CSS: url of custom css stylesheet (optional)
 
 You can also add a "_FILE" suffix to each variable name and pass a path to read the value from a file instead. For example instead of passing `SECRET_KEY`:
 


### PR DESCRIPTION
This adds the configuration variables from https://edumfa.readthedocs.io/en/v2.9.0/faq/customization.html to the possible values set from the docker environment.

The commit also slightly changes the semantics of `get_var`: Where before, a falsy value was treated as "variable not set", it now just checks if the variable is not set (as documented).

For existing users, this somewhat depends on https://github.com/eduMFA/eduMFA/issues/985