### PR TITLE
docs: add integration chapter

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -47,6 +47,7 @@ Table of Contents
    eventhandler/index
    periodictask/index
    audit/index
+   integrations/index
    machines/index
    workflows_and_tools/index
    jobqueue/index
@@ -56,7 +57,7 @@ Table of Contents
 
 
 If you are missing any information or descriptions
-file an issue at `github <https://github.com/eduMFA/eduMFA/issues>`_ (which would be the preferred way),
+file an issue at `GitHub <https://github.com/eduMFA/eduMFA/issues>`_ (which would be the preferred way),
 or drop a note to edumfa(@)listserv.dfn.de.
 
 This will help us a lot to improve documentation to your needs.

--- a/doc/installation/ubuntu.rst
+++ b/doc/installation/ubuntu.rst
@@ -90,24 +90,6 @@ alternatively use the meta package ``edumfa-nginx``.
 
 Now you may proceed to :ref:`first_steps`.
 
-
-.. _install_ubuntu_freeradius:
-
-FreeRADIUS
-..........
-
-eduMFA has a perl module to "translate" RADIUS requests to the API of the
-eduMFA server. This module plugs into FreeRADIUS. The FreeRADIUS does not
-have to run on the same machine as eduMFA.
-To install this module run::
-
-   apt-get install edumfa-radius
-
-For further details see :ref:`rlm_perl`.
-
-.. rubric:: Footnotes
-
-
 Building your own Packages
 ...........................
 To build custom packages from the source code, follow these steps meticulously:

--- a/doc/installation/upgrade.rst
+++ b/doc/installation/upgrade.rst
@@ -98,3 +98,4 @@ using::
    apt dist-upgrade
 
 
+.. _READ_BEFORE_UPDATE: https://github.com/eduMFA/eduMFA/blob/main/READ_BEFORE_UPDATE.md

--- a/doc/integrations/freeradius.rst
+++ b/doc/integrations/freeradius.rst
@@ -1,0 +1,126 @@
+.. _freeradius_integration:
+
+FreeRADIUS
+----------
+
+.. index:: FreeRADIUS
+
+eduMFA has a perl module to "translate" RADIUS requests to the API of the
+eduMFA server. This module plugs into FreeRADIUS. The FreeRADIUS does not
+have to run on the same machine as eduMFA.
+
+Installation
+~~~~~~~~~~~~
+
+There are two installation options available: Ubuntu packages and manual installation.
+
+Ubuntu package
+..............
+
+First add the repository as described in :ref:`add_ubuntu_repository`.
+
+
+After having added the repositories, run::
+
+   sudo apt update
+   sudo apt install edumfa-radius
+
+.. _freeradius_manual_installation:
+
+Manual installation
+...................
+
+If not installed already, install FreeRADIUS. On Ubuntu, this would be as simple
+as doing ``apt install freeradius``.
+
+Then install the necessary Perl modules. On Ubuntu this would mean::
+
+   sudo apt install libwww-perl libconfig-inifiles-perl libdata-dump-perl libtry-tiny-perl libjson-perl liblwp-protocol-https-perl liburi-encode-perl
+
+Download the script and place it appropriately. Replace the version with your
+eduMFA version (here: v2.9.0)::
+
+   wget https://raw.githubusercontent.com/eduMFA/eduMFA/refs/tags/v2.9.0/deploy/edumfa_radius.pm
+   sudo mkdir -p /usr/share/edumfa/freeradius
+   sudo mv edumfa_radius.pm /usr/share/edumfa/freeradius/
+
+Do the same for the configuration file::
+
+   wget https://raw.githubusercontent.com/eduMFA/eduMFA/refs/tags/v2.9.0/deploy/rlm_perl.ini
+   sudo mkdir /etc/edumfa
+   sudo mv rlm_perl.ini /etc/edumfa/
+
+As well for the module configuration (the target path might be different
+depending on your operating system)::
+
+   wget https://raw.githubusercontent.com/eduMFA/eduMFA/refs/tags/v2.9.0/deploy/config/freeradius3/mods-perl-edumfa
+   sudo mv mods-perl-edumfa /etc/freeradius/3.0/mods-available/
+   sudo ln -s /etc/freeradius/3.0/mods-available/mods-perl-edumfa /etc/freeradius/3.0/mods-enabled/
+
+Now the module has to be integrated into your site configuration. If this is a
+new FreeRADIUS server just for eduMFA, you might want to copy the configuration
+from our packages and remove other sites::
+
+   wget https://raw.githubusercontent.com/eduMFA/eduMFA/refs/tags/v2.9.0/deploy/config/freeradius3/edumfa
+   sudo mv edumfa /etc/freeradius/3.0/sites-available/
+   sudo bash -c "rm -f /etc/freeradius/3.0/sites-enabled/*"
+   sudo ln -s /etc/freeradius/3.0/sites-available/edumfa /etc/freeradius/3.0/sites-enabled/
+   # disable unused EAP module
+   sudo rm /etc/freeradius/3.0/mods-enabled/eap
+
+Restart FreeRADIUS - you can test the server with the ``radclient`` package::
+
+   echo "User-Name=username,User-Password=pass123456" | radclient -x localhost:1812 auth testing123
+
+Remember to add your client configuration to FreeRADIUS.
+
+Configuration
+~~~~~~~~~~~~~
+
+The configuration of the plugin is done via the ``rlm_perl.ini`` file. It tries
+the following paths per default:
+
+- ``/etc/edumfa/rlm_perl.ini``
+- ``/etc/freeradius/rlm_perl.ini``
+- ``/opt/eduMFA/rlm_perl.ini``
+
+Alternatively you can specify a path in the module definition:
+
+.. code-block::
+   filename = /usr/share/edumfa/freeradius/edumfa_radius.pm
+   config {
+     configfile = /etc/edumfa/rlm_perl-A.ini
+   }
+
+If no configuration can be found, the default values are::
+
+   [Default]
+   URL = https://localhost/validate/check
+   REALM =
+
+For possible configuration options, please see the content of the configuration
+file.
+
+.. note:: The requests from RADIUS have two interesting headers: User-Agent and
+   RADIUS-NAS-Identifier. The first is "FreeRADIUS" while the second corresponds
+   to the NAS Identifier sent by the RADIUS client (for example OpenVPN). You
+   can use these two in addition the the client IP to create elaborate policies!
+
+Upgrading
+~~~~~~~~~
+
+It is recommended to keep ``/usr/share/edumfa/freeradius/edumfa_radius.pm`` in
+sync with your eduMFA version. When upgrading eduMFA:
+
+1. Read the `READ_BEFORE_UPDATE`_ file for the release you're upgrading to (and
+   those in between if you're jumping more than one version). It could contain
+   information about recommended or necessary changes to the plugin's
+   configuration.
+2. Update ``/usr/share/edumfa/freeradius/edumfa_radius.pm`` by replacing the
+   file with the version of the release you're upgrading to.
+   See :ref:`freeradius_manual_installation` for help on how to do that.
+3. Update your configuration as necessary.
+4. Restart FreeRADIUS.
+
+
+.. _READ_BEFORE_UPDATE: https://github.com/eduMFA/eduMFA/blob/main/READ_BEFORE_UPDATE.md

--- a/doc/integrations/index.rst
+++ b/doc/integrations/index.rst
@@ -1,0 +1,19 @@
+.. _integrations:
+
+Integrations
+============
+
+.. index:: integrations
+
+eduMFA can be integrated into applications via different ways. All of them
+utilize the :ref:`REST API <api>`, which can also be used for custom integrations. Below is a
+list of eduMFA-specific plugins.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   shibboleth.rst
+   freeradius.rst
+   ldap_proxy.rst
+   openvpn.rst

--- a/doc/integrations/ldap_proxy.rst
+++ b/doc/integrations/ldap_proxy.rst
@@ -1,0 +1,16 @@
+.. _ldap_proxy:
+
+LDAP Proxy
+----------
+
+.. index:: LDAP Proxy
+
+Some applications can only be connected via LDAP. For these cases there is a
+proxy available which intercepts these requests. Users can then enter their
+username as well as their password suffixed with the OTP value, which will get
+split up by the proxy. This also means that tokentypes like WebAuthN and EDUPUSH
+will not work.
+
+You can find edumfa-ldap-proxy and its documentation here_.
+
+.. _here: https://gitlab.daasi.de/edumfa/edumfa-ldap-proxy

--- a/doc/integrations/openvpn.rst
+++ b/doc/integrations/openvpn.rst
@@ -1,0 +1,23 @@
+.. _openvpn_integration:
+
+OpenVPN
+-----------
+
+.. index:: OpenVPN
+
+OpenVPN can be connected to eduMFA via two ways: the OpenVPN RADIUS plugin and
+edumfa-openvpn-radius.
+
+The `OpenVPN RADIUS plugin`_ offers better performance, more features, and is
+available in most repositories. It requires the use of the
+:ref:`FreeRADIUS integration<freeradius_integration>`. After setting it up, you
+can point the OpenVPN plugin at the FreeRADIUS server.
+
+This setup does not support challenge response, which might be helpful during
+migration periods. In these cases, edumfa-openvpn-radius might be a (temporary)
+solution. It supports the ``crtext`` protocol of OpenVPN, which enables doing
+proper challenge/response (i.e. requesting the OTP value if necessary as a
+separate step). Documentation and source code can be found here_.
+
+.. _OpenVPN radius plugin: https://www.nongnu.org/radiusplugin/
+.. _here: https://gitlab.daasi.de/edumfa/edumfa-openvpn-radius

--- a/doc/integrations/shibboleth.rst
+++ b/doc/integrations/shibboleth.rst
@@ -1,0 +1,16 @@
+.. _shibboleth_integration:
+
+Shibboleth
+-----------
+
+.. index:: Shibboleth
+
+For the `Shibboleth Identity Provider`_ there is the fudiscr plugin. It has
+comprehensive support for eduMFA features, including Passkeys. The documentation
+can be found on the website of the DFN (English_, German_).
+
+The German version tends to be more up-to-date than the English one.
+
+.. _Shibboleth Identity Provider: https://shibboleth.atlassian.net/wiki/spaces/IDP5/overview
+.. _English: https://doku.tid.dfn.de/en:shibidp:plugin-fudiscr
+.. _German: https://doku.tid.dfn.de/de:shibidp:plugin-fudiscr

--- a/doc/modules/index.rst
+++ b/doc/modules/index.rst
@@ -7,6 +7,8 @@ The code roughly has three levels: API, LIB and DB.
 
 .. index:: JWT, JSON Web Token
 
+.. _code_docu_rest_api:
+
 API level
 ---------
 The API level is used to access the system. 

--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -1,5 +1,4 @@
 eduMFA
-eduMFA
 Yubikey
 Yubikeys
 Yubico


### PR DESCRIPTION
Add a chapter about connection possibilities to the docs. Main reason is a complaint I got about there being no instructions for manual installation of RADIUS.  
The other pages are pretty bare-bones but probably enough for discoverability?