### PR TITLE
fix(image): ensure upgradability of edumfa config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ VOLUME ["/etc/edumfa"]
 
 # Copy necessary files
 COPY ./deploy/docker/entrypoint.sh /opt/edumfa/entrypoint.sh
-COPY ./deploy/docker/edumfa.py /etc/edumfa/edumfa.cfg
-COPY ./deploy/docker/logging.yml /etc/edumfa/logging.yml
+COPY ./deploy/docker/edumfa_config.py /opt/edumfa/edumfa_config.py
+COPY ./deploy/docker/logging.yml /opt/edumfa/logging.yml
 COPY ./deploy/gunicorn/edumfaapp.py /opt/edumfa/app.py
 
 # Create directory for user scripts

--- a/deploy/docker-example/docker-compose.yml
+++ b/deploy/docker-example/docker-compose.yml
@@ -26,12 +26,13 @@ services:
       - ./edumfa-setup.sh:/opt/edumfa/user-scripts/01-setup.sh:ro
       - ./example-policy.py:/opt/edumfa/policy.py:ro
       - ./my-login.html:/opt/edumfa/edumfa-package/static/components/login/views/login.html
-      - ./db_password.txt:/etc/edumfa/db_password.txt:ro
+    secrets:
+      - db_password
     environment:
       DB_DRIVER: ${DB_DRIVER}
       DB_HOSTNAME: mariadb
       DB_USER: ${MARIADB_USER}
-      DB_PASSWORD_FILE: /etc/edumfa/db_password.txt
+      DB_PASSWORD_FILE: /run/secrets/db_password
       DB_DATABASE: ${MARIADB_DATABASE}
       SECRET_KEY: ${EDUMFA_SECRET_KEY}
       EDUMFA_PEPPER: ${EDUMFA_PEPPER}
@@ -41,6 +42,10 @@ services:
     depends_on:
       mariadb:
         condition: service_healthy
+
+secrets:
+  db_password:
+    file: ./db_password.txt
 
 volumes:
   edumfa-keys:

--- a/deploy/docker-example/env-example
+++ b/deploy/docker-example/env-example
@@ -6,7 +6,7 @@ MARIADB_ROOT_PASSWORD="rootpass"
 
 DB_DRIVER="mysql+pymysql"
 
-EDUMFA_SECRET_KEY="Test"
+EDUMFA_SECRET_KEY="Secret-Use-Your-Own-Values-Please"
 EDUMFA_PEPPER="Never know..."
 
 EDUMFA_ADMIN_USER="admin"

--- a/deploy/docker/edumfa_config.py
+++ b/deploy/docker/edumfa_config.py
@@ -59,7 +59,7 @@ EDUMFA_ENCFILE = "/etc/edumfa/enckey"
 EDUMFA_AUDIT_KEY_PRIVATE = "/etc/edumfa/private.pem"
 EDUMFA_AUDIT_KEY_PUBLIC = "/etc/edumfa/public.pem"
 EDUMFA_LOGFILE = "/var/log/edumfa/edumfa.log"
-EDUMFA_LOGCONFIG = "/etc/edumfa/logging.yml"
+EDUMFA_LOGCONFIG = get_var("EDUMFA_LOGCONFIG", "/opt/edumfa/logging.yml")
 EDUMFA_UI_DEACTIVATED = get_var("EDUMFA_UI_DEACTIVATED", "False") == "True"
 EDUMFA_AUDIT_SQL_TRUNCATE = True
 EDUMFA_NODE = gethostname()

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,6 +1,61 @@
 #!/usr/bin/bash
 set -e
 
+# In eduMFA v2.9.0, the config and logging file were suggested to be put into a
+# volume. This would lead to them not getting updated. This is a workaround to
+# handle this unfortunate situation:
+# If they are the same as in that release, delete them.
+# If both were changed, the operator should be aware of the situation.
+# If only one of the files was changed, the situation is ambiguous.
+# This workaround will be deleted in v3.0.0.
+config_equal="false"
+logging_equal="false"
+if [ -e "/etc/edumfa/edumfa.cfg" ]; then
+  config_hash="$(sha256sum /etc/edumfa/edumfa.cfg | cut -d " " -f 1 )"
+  if [ "$config_hash" == "a87cf5f96a5eb1ceb0f6d59c9083814e2c55bf7c3b85ca8ecdb532dc059fa064" ]; then
+    config_equal="true"
+  fi
+fi
+if [ -e "/etc/edumfa/logging.yml" ]; then
+  logging_hash="$(sha256sum /etc/edumfa/logging.yml | cut -d " " -f 1 )"
+  if [ "$logging_hash" == "447d9ab4f18505e6acc441a94a68e2a3410125c37b6bc942ad0c5523a1caf6f9" ]; then
+    logging_equal="true"
+  fi
+fi
+if [[ "$config_equal" == "true" && "$logging_equal" == "true" ]]; then
+  # No changes to either file. This should be the most common scenario, since
+  # the example compose file relied on environment variables to configure
+  # eduMFA.
+  rm -f "/etc/edumfa/edumfa.cfg"
+  rm -f "/etc/edumfa/logging.yml"
+elif [[ "$config_equal" != "true" && "$logging_equal" != "true" ]]; then
+  # Both files were edited and/or already deleted.
+  true
+else
+  # Only one file was edited, the situation is ambigious.
+  echo "=======================================================================
+  Due to an error in v2.9.0, the following files were moved:
+  /etc/edumfa/edumfa.cfg ==> /opt/edumfa/edumfa.cfg
+  /etc/edumfa/logging.yml ==> /opt/edumfa/logging.yml
+  Please update your deployments if necessary.
+  This warning will disappear in eduMFA 3.0.0."
+  echo "======================================================================="
+fi
+
+# Decide which config file to use. The hierarchy is as follows:
+# 0. Use $EDUMFA_CONFIGFILE if it is set.
+# 1. Use /etc/edumfa/edumfa.cfg if it exists.
+# 2. Use this container's /opt/edumfa/edumfa_config.py.
+if [ -v EDUMFA_CONFIGFILE ]; then
+  export EDUMFA_CONFIGFILE
+elif [ -e "/etc/edumfa/edumfa.cfg" ]; then
+  export EDUMFA_CONFIGFILE="/etc/edumfa/edumfa.cfg"
+else
+  export EDUMFA_CONFIGFILE="/opt/edumfa/edumfa_config.py"
+fi
+# Make sure the config is working by executing it once.
+python3 "$EDUMFA_CONFIGFILE"
+
 GEN_PWD="$(openssl rand -base64 42)"
 EDUMFA_ADMIN_USER="${EDUMFA_ADMIN_USER:-admin}"
 # Check if password is set, otherwise generate one later.
@@ -10,9 +65,6 @@ if [ -z "$EDUMFA_ADMIN_PASS" ]; then
   GENERATED_PASSWORD=1
 fi
 EDUMFA_ADMIN_PASS="${EDUMFA_ADMIN_PASS:-$GEN_PWD}"
-
-# Make sure the config is working by executing it once.
-python3 "/etc/edumfa/edumfa.cfg"
 
 # Create enckey if doesn't exist yet
 edumfa-manage -q create_enckey || true
@@ -38,7 +90,7 @@ edumfa-manage -q admin add "$EDUMFA_ADMIN_USER" -p "$EDUMFA_ADMIN_PASS"
 shopt -s nullglob
 for script in /opt/edumfa/user-scripts/*.sh; do
   echo "Executing user script $script..."
-  bash $script
+  bash "$script"
 done
 
 if [ $GENERATED_PASSWORD -eq 1 ]; then

--- a/doc/installation/docker.rst
+++ b/doc/installation/docker.rst
@@ -80,6 +80,7 @@ The `.env` file should contain the following variables:
 - EDUMFA_PEPPER: the pepper to use for password hashing, should be at least 24 random characters long
 - EDUMFA_ADMIN_USER: the username for the local eduMFA admin (optional)
 - EDUMFA_ADMIN_PASS: the password for the local eduMFA admin (optional)
+- EDUMFA_LOGCONFIG: a path to an alternative logging config (optional)
 - SUPERUSER_REALM: which realms should be superuser realms (optional)
 - EDUMFA_UI_DEACTIVATED: whether to disable the WebUI (optional)
 - EDUMFA_LOGO: filename of custom logo (optional)


### PR DESCRIPTION
Deletes the old files if `edumfa.cfg` has the correct hash. Moves the files to `/opt`, which is not part of any volume.  
fixes #1043
fixes #985  

TODO: If merged, add a new issue for 3.0.0 to remove the workaround.