### PR TITLE
docs(changelog): warn Ubuntu package users not to overwrite edumfa.cfg

### DIFF
--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -49,7 +49,7 @@ This release focuses on stability, security, and long-term maintainability. It c
 
 > [!CAUTION]
 >
-> Due to new fields in `edumfa.cfg`, updating your Ubuntu package will cause apt to ask you to replace it. Replacing that file will result in losing the secrets set in it (and you having to add those secrets back). If needed, add the new fields manually to your existing `edumfa.cfg`.
+> Due to new fields in `edumfa.cfg`, upgrading via Ubuntu packages prompts apt to replace that file. Replacing it can remove secrets from your current configuration, so keep your existing file and add only the new fields manually.
 >
 
 ### Added

--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -49,7 +49,7 @@ This release focuses on stability, security, and long-term maintainability. It c
 
 > [!CAUTION]
 >
-> Due to new fields in `edumfa.cfg`, upgrading via Ubuntu packages prompts apt to replace that file. Replacing it can remove secrets from your current configuration, so keep your existing file and add only the new fields manually.
+> Due to new fields in `edumfa.cfg`, upgrading via Ubuntu packages causes apt to prompt you to replace it. Replacing it will remove secrets from your current configuration, so keep your existing file and add only the new fields manually.
 >
 
 ### Added

--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -47,6 +47,11 @@ This release focuses on stability, security, and long-term maintainability. It c
 > The 3.0.0 release of eduMFA is planned to remove multiple features. This will be announced as soon as there is a complete list. A work in progress list of removals can be found at: https://github.com/eduMFA/eduMFA/issues/875
 >
 
+> [!CAUTION]
+>
+> Due to new fields in `edumfa.cfg`, updating your Ubuntu package will cause apt to ask you to replace it. Replacing that file will result in losing the secrets set in it (and you having to add those secrets back). If needed, add the new fields manually to your existing `edumfa.cfg`.
+>
+
 ### Added
 
 - Added support for Python 3.14 ([#796](https://github.com/eduMFA/eduMFA/pull/796)) (@Luc1412)


### PR DESCRIPTION
Warn about apt wanting to replace `edumfa.cfg`. Maybe we should set the secrets separately from the config, as we do in the container image?  
This has caused at least confusion for two users. 