### PR TITLE
change handling of entrypoint, use exec "$@" and CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,5 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PATH="/opt/edumfa:$PATH"
 
-CMD ["./entrypoint.sh"]
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--workers", "4", "app"]

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -46,7 +46,7 @@ fi
 # 0. Use $EDUMFA_CONFIGFILE if it is set.
 # 1. Use /etc/edumfa/edumfa.cfg if it exists.
 # 2. Use this container's /opt/edumfa/edumfa_config.py.
-if [ -v EDUMFA_CONFIGFILE ]; then
+if [ -n "$EDUMFA_CONFIGFILE" ]; then
   export EDUMFA_CONFIGFILE
 elif [ -e "/etc/edumfa/edumfa.cfg" ]; then
   export EDUMFA_CONFIGFILE="/etc/edumfa/edumfa.cfg"
@@ -102,4 +102,4 @@ if [ $GENERATED_PASSWORD -eq 1 ]; then
 fi
 
 echo "Starting Server"
-gunicorn --bind 0.0.0.0:8000 --workers 4 app
+exec "$@"


### PR DESCRIPTION
It would be better to set the gunicorn command in the CMD of the dockerfile and only `exec "$@"` in the entrypoint script. This allows users to more easily customize the gunicorn arguments, for example if a different port should be used or ssl certificates should be provided. 

Also, it makes more sense to check if  EDUMFA_CONFIGFILE is not empty. Currently, if the environment variable is set but an empty string the logic fails.