### PR TITLE
docs(tokens): update supported token guidance and app recommendations

### DIFF
--- a/doc/tokens/supported_tokens.rst
+++ b/doc/tokens/supported_tokens.rst
@@ -48,12 +48,12 @@ button tokens. The C100 is an :ref:`hotp_token` token and the C200 a
 tokens are initialized at the factory and you get a seed file, that you need
 to import to eduMFA.
 
-**Passkeys**. Yubikeys are known to work well with eduMFA, but the quality of
-all tokens depend on the implementation of the software surrounding it. On some
-Android devices, Passkey logins with certain (?) hardware tokens seems to have
-issues . This is not something we have an influence on. We recommend testing
-tokens before buying them in bulk, e.g. using one of the available
-`testing websites`_. See :ref:`webauthn` for more information on WebAuthN.
+**Passkeys**. Yubikeys are known to work well with eduMFA, but token
+compatibility depends on the implementation of the surrounding software. On
+some Android devices, passkey logins with certain hardware tokens can fail.
+This is outside of eduMFA's control. We recommend testing tokens before buying
+them in bulk, e.g. using one of the available `testing websites`_. See
+:ref:`webauthn` for more information on WebAuthN.
 
 Smartphone Apps
 ~~~~~~~~~~~~~~~

--- a/doc/tokens/supported_tokens.rst
+++ b/doc/tokens/supported_tokens.rst
@@ -60,8 +60,6 @@ Smartphone Apps
 
 .. index:: Software Tokens
 
-.. _privacyidea_authenticator:
-
 **Aegis Authenticator**. An open source :ref:`totp_token` and :ref:`hotp_token`
 app for Android.
 
@@ -77,6 +75,8 @@ enrollment, you can scan a QR Code with the Google Authenticator.
 See :ref:`first_steps_token` to learn how to do this.
 
 **mOTP**. Several mOTP Apps like "Potato", "Token2" or "DroidOTP" are supported.
+
+.. _privacyidea_authenticator:
 
 **privacyIDEA Authenticator (unsupported)**. privacyIDEA Authenticator is based
 on the concept of the Google Authenticator and works with the usual QR Code

--- a/doc/tokens/supported_tokens.rst
+++ b/doc/tokens/supported_tokens.rst
@@ -4,9 +4,9 @@ Hardware and Software Tokens
 ............................
 
 eduMFA supports a wide variety of tokens by different hardware vendors.
-It also supports token apps on the smartphone which handle software tokens.
+It also supports token apps on smartphones, which handle software tokens.
 
-Tokens not listed, will be probably supported, too, since most tokens use
+Tokens not listed will be probably supported, too, since most tokens use
 standard algorithms.
 
 If in doubt drop your question on the mailing list.
@@ -48,8 +48,12 @@ button tokens. The C100 is an :ref:`hotp_token` token and the C200 a
 tokens are initialized at the factory and you get a seed file, that you need
 to import to eduMFA.
 
-**U2F**. The Yubikey and the Daplug token are known U2F devices to work well
-with eduMFA. See :ref:`u2f_token`.
+**Passkeys**. Yubikeys are known to work well with eduMFA, but the quality of
+all tokens depend on the implementation of the software surrounding it. On some
+Android devices, Passkey logins with certain (?) hardware tokens seems to have
+issues . This is not something we have an influence on. We recommend testing
+tokens before buying them in bulk, e.g. using one of the available
+`testing websites`_. See :ref:`webauthn` for more information on WebAuthN.
 
 Smartphone Apps
 ~~~~~~~~~~~~~~~
@@ -58,11 +62,12 @@ Smartphone Apps
 
 .. _privacyidea_authenticator:
 
-**privacyIDEA Authenticator (unsupported)**. privacyIDEA Authenticator is based
-on the concept of the Google Authenticator and works with the usual QR Code key URI
-enrollment. But on top it also allows for a more secure
-enrollment process (See :ref:`2step_enrollment`).
-It can be used for :ref:`hotp_token`, :ref:`totp_token`, :ref:`edupush_token` and :ref:`push_token`.
+**Aegis Authenticator**. An open source :ref:`totp_token` and :ref:`hotp_token`
+app for Android.
+
+**FreeOTP**. eduMFA is known to work well with the FreeOTP app. The
+FreeOTP app supports only :ref:`totp_token`. So if you scan the QR Code of an
+HOTP token, the OTP will not validate. It also has a version for iOS.
 
 **Google Authenticator**. The Google Authenticator is working well in
 :ref:`hotp_token`
@@ -71,8 +76,13 @@ during
 enrollment, you can scan a QR Code with the Google Authenticator.
 See :ref:`first_steps_token` to learn how to do this.
 
-**FreeOTP**. eduMFA is known to work well with the FreeOTP App. The
-FreeOTP App is a :ref:`totp_token` token. So if you scan the QR Code of an
-HOTP token, the OTP will not validate.
-
 **mOTP**. Several mOTP Apps like "Potato", "Token2" or "DroidOTP" are supported.
+
+**privacyIDEA Authenticator (unsupported)**. privacyIDEA Authenticator is based
+on the concept of the Google Authenticator and works with the usual QR Code
+enrollment. But on top it also allows for a two step enrollment process (See
+:ref:`2step_enrollment`).
+It can be used for :ref:`hotp_token`, :ref:`totp_token`, :ref:`edupush_token` and :ref:`push_token`.
+
+
+.. _testing websites: https://www.passkeys.io/

--- a/doc/tokens/supported_tokens.rst
+++ b/doc/tokens/supported_tokens.rst
@@ -68,11 +68,7 @@ FreeOTP app supports only :ref:`totp_token`. So if you scan the QR Code of an
 HOTP token, the OTP will not validate. It also has a version for iOS.
 
 **Google Authenticator**. The Google Authenticator is working well in
-:ref:`hotp_token`
-and :ref:`totp_token` mode. If you choose "Generate OTP Key on the Server"
-during
-enrollment, you can scan a QR Code with the Google Authenticator.
-See :ref:`first_steps_token` to learn how to do this.
+:ref:`HOTP <hotp_token>` and :ref:`totp_token` mode.
 
 **mOTP**. Several mOTP Apps like "Potato", "Token2" or "DroidOTP" are supported.
 


### PR DESCRIPTION
Replace U2F with Webauthn, as the former is not relevant anymore.  
Also add Aegis since it does HOTP, too and looks more modern than FreeOTP. 2FAS is not open source so I did not add it. Reordered the list alphabetically.