### PR TITLE
docs(webauthn): warn that passkeys can bypass resolver lock checks

### DIFF
--- a/doc/integrations/shibboleth.rst
+++ b/doc/integrations/shibboleth.rst
@@ -11,6 +11,19 @@ can be found on the website of the DFN (English_, German_).
 
 The German version tends to be more up-to-date than the English one.
 
+.. warning:: When using Passkeys/fudispasskeys, keep in mind
+   the authentication will not involve your resolver. For LDAP resolvers, this
+   would mean those Passkeys work for locked/deactivated users, too.
+
+   Make sure your client (e.g. your IDP) checks the status of your users.
+   Alternatively, you can exclude disabled users in your resolver as a
+   workaround using the search filter. Tokens belonging to those users will be
+   considered orphaned by the token janitor, though.
+
+   See `issue #1005`_ for more information.
+
+
 .. _Shibboleth Identity Provider: https://shibboleth.atlassian.net/wiki/spaces/IDP5/overview
 .. _English: https://doku.tid.dfn.de/en:shibidp:plugin-fudiscr
 .. _German: https://doku.tid.dfn.de/de:shibidp:plugin-fudiscr
+.. _issue #1005: https://github.com/eduMFA/eduMFA/issues/1005

--- a/doc/integrations/shibboleth.rst
+++ b/doc/integrations/shibboleth.rst
@@ -20,10 +20,9 @@ The German version tends to be more up-to-date than the English one.
    workaround using the search filter. Tokens belonging to those users will be
    considered orphaned by the token janitor, though.
 
-   See `issue #1005`_ for more information.
+   See `issue #1005 <https://github.com/eduMFA/eduMFA/issues/1005>`_ for more information.
 
 
 .. _Shibboleth Identity Provider: https://shibboleth.atlassian.net/wiki/spaces/IDP5/overview
 .. _English: https://doku.tid.dfn.de/en:shibidp:plugin-fudiscr
 .. _German: https://doku.tid.dfn.de/de:shibidp:plugin-fudiscr
-.. _issue #1005: https://github.com/eduMFA/eduMFA/issues/1005

--- a/doc/tokens/tokentypes/webauthn.rst
+++ b/doc/tokens/tokentypes/webauthn.rst
@@ -24,8 +24,22 @@ The devices is identified and assigned to the user.
 .. note:: As the key pair is only generated virtually, you can register one
     physical device for several users.
 
+.. warning:: When using WebAuthN tokens as Passkeys/resident keys, keep in mind
+   the authentication will not involve your resolver. For LDAP resolvers, this
+   would mean those Passkeys work for locked/deactivated users, too.
+
+   Make sure your client (e.g. your IDP) checks the status of your users.
+   Alternatively, you can exclude disabled users in your resolver as a
+   workaround using the search filter. Tokens belonging to those users will be
+   considered orphaned by the token janitor, though.
+
+   See `issue #1005`_ for more information.
+
 For configuring eduMFA for the use of WebAuthn tokens, please see
 :ref:`webauthn_otp_token`.
 
 For further details and information how to add this to your application, see
 the code documentation at :ref:`code_webauthn_token`.
+
+
+.. _issue #1005: https://github.com/eduMFA/eduMFA/issues/1005

--- a/doc/tokens/tokentypes/webauthn.rst
+++ b/doc/tokens/tokentypes/webauthn.rst
@@ -33,13 +33,10 @@ The devices is identified and assigned to the user.
    workaround using the search filter. Tokens belonging to those users will be
    considered orphaned by the token janitor, though.
 
-   See `issue #1005`_ for more information.
+   See `issue #1005 <https://github.com/eduMFA/eduMFA/issues/1005>`_ for more information.
 
 For configuring eduMFA for the use of WebAuthn tokens, please see
 :ref:`webauthn_otp_token`.
 
 For further details and information how to add this to your application, see
 the code documentation at :ref:`code_webauthn_token`.
-
-
-.. _issue #1005: https://github.com/eduMFA/eduMFA/issues/1005

--- a/doc/tokens/tokentypes/webauthn.rst
+++ b/doc/tokens/tokentypes/webauthn.rst
@@ -24,7 +24,7 @@ The devices is identified and assigned to the user.
 .. note:: As the key pair is only generated virtually, you can register one
     physical device for several users.
 
-.. warning:: When using WebAuthN tokens as Passkeys/resident keys, keep in mind
+.. warning:: When using WebAuthn tokens as Passkeys/resident keys, keep in mind
    the authentication will not involve your resolver. For LDAP resolvers, this
    would mean those Passkeys work for locked/deactivated users, too.
 


### PR DESCRIPTION
Add a warning to the documentation regarding #1005 . It will also need a prominent spot in the changelog imo.  
closes #1005 