### PR TITLE
fix(image): fix reading admin credentials from file

### DIFF
--- a/deploy/docker-example/admin_password.txt
+++ b/deploy/docker-example/admin_password.txt
@@ -1,0 +1,1 @@
+admin_password_123

--- a/deploy/docker-example/docker-compose.yml
+++ b/deploy/docker-example/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - ./my-login.html:/opt/edumfa/edumfa-package/static/components/login/views/login.html
     secrets:
       - db_password
+      - admin_password
     environment:
       DB_DRIVER: ${DB_DRIVER}
       DB_HOSTNAME: mariadb
@@ -37,7 +38,7 @@ services:
       SECRET_KEY: ${EDUMFA_SECRET_KEY}
       EDUMFA_PEPPER: ${EDUMFA_PEPPER}
       EDUMFA_ADMIN_USER: ${EDUMFA_ADMIN_USER}
-      EDUMFA_ADMIN_PASS: ${EDUMFA_ADMIN_PASS}
+      EDUMFA_ADMIN_PASS_FILE: /run/secrets/admin_password
       EDUMFA_UI_DEACTIVATED: ${EDUMFA_UI_DEACTIVATED}
     depends_on:
       mariadb:
@@ -46,6 +47,8 @@ services:
 secrets:
   db_password:
     file: ./db_password.txt
+  admin_password:
+    file: ./admin_password.txt
 
 volumes:
   edumfa-keys:

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -56,15 +56,20 @@ fi
 # Make sure the config is working by executing it once.
 python3 "$EDUMFA_CONFIGFILE"
 
-GEN_PWD="$(openssl rand -base64 42)"
+if [ -n "$EDUMFA_ADMIN_USER_FILE" ]; then
+  EDUMFA_ADMIN_USER=$(cat "$EDUMFA_ADMIN_USER_FILE")
+fi
 EDUMFA_ADMIN_USER="${EDUMFA_ADMIN_USER:-admin}"
-# Check if password is set, otherwise generate one later.
+# Check if password is set, otherwise generate one.
 GENERATED_PASSWORD=0
+if [ -n "$EDUMFA_ADMIN_PASS_FILE" ]; then
+  EDUMFA_ADMIN_PASS=$(cat "$EDUMFA_ADMIN_PASS_FILE")
+fi
 if [ -z "$EDUMFA_ADMIN_PASS" ]; then
   echo "No EDUMFA_ADMIN_PASS set, a random password will be generated and printed when initialization finishes."
+  EDUMFA_ADMIN_PASS="$(openssl rand -base64 42)"
   GENERATED_PASSWORD=1
 fi
-EDUMFA_ADMIN_PASS="${EDUMFA_ADMIN_PASS:-$GEN_PWD}"
 
 # Create enckey if doesn't exist yet
 edumfa-manage -q create_enckey || true


### PR DESCRIPTION
In https://edumfa.readthedocs.io/en/v2.9.0/installation/docker.html#docker-compose there's a claim about each setting also being able to be read from files. This is not true for the admin credentials, as they are not read via the config, but the entrypoint.  
This patch adds support for reading them from file, too. This is probably more useful for the password than for the username, but for the sake of completeness...
I've intentionally let empty files be handled the same as empty variables to have uniform behaviour.