### PR TITLE
fix: radiusserver message authenticator

### DIFF
--- a/edumfa/lib/radiusserver.py
+++ b/edumfa/lib/radiusserver.py
@@ -128,10 +128,12 @@ class RADIUSServer:
         try:
             response = srv.SendPacket(req)
             if config.enforce_ma:
-                # verify_message_authenticator() raised a generic exception
+                # verify_message_authenticator() raises a generic exception
                 # if M-A attribute is missing .. check for it before!
                 if "Message-Authenticator" in response:
-                    success = response.verify_message_authenticator()
+                    success = response.verify_message_authenticator(
+                        original_authenticator=req.authenticator
+                    )
                     if not success:
                         log.info(
                             f"Radiusserver {config.server} sent broken"

--- a/edumfa/static/components/config/controllers/radiusServerController.js
+++ b/edumfa/static/components/config/controllers/radiusServerController.js
@@ -77,7 +77,7 @@ myApp.controller("radiusServerController", ["$scope", "$stateParams", "inform",
            if (data.result.value === true) {
                inform.add(gettextCatalog.getString("RADIUS request" +
                    " successful."),
-                   {type: "info"});
+                   {type: "success"});
            } else {
                inform.add(gettextCatalog.getString("RADIUS request failed!"),
                    {type: "danger"});

--- a/tests/test_lib_radiusserver.py
+++ b/tests/test_lib_radiusserver.py
@@ -157,6 +157,10 @@ class RADIUSServerTestCase(MyTestCase):
 
     @radiusmock.activate
     def test_08_RADIUS_request_ma(self):
+        # TODO: Some of these tests should probably have failed without the
+        # change in commit "fix: radiusserver message authenticator". They
+        # didn't, and it would be nice to have a unit test covering that at
+        # least. But for now there's no time..
         radiusmock.setdata(response=radiusmock.AccessAccept)
         r = add_radius(
             identifier="myserver",


### PR DESCRIPTION
Fixes the Message-Authenticator for RADIUS requests. Tested with FreeRADIUS.  
Possible context:
- https://www.rfc-editor.org/rfc/rfc3579#page-16
- https://github.com/pyradius/pyrad/blob/2.5.4/pyrad/packet.py#L144-L149  
