### PR TITLE
fix: fudiscr error for unassigned passkeys

### DIFF
--- a/edumfa/lib/tokens/webauthntoken.py
+++ b/edumfa/lib/tokens/webauthntoken.py
@@ -1617,11 +1617,13 @@ class WebAuthnTokenClass(TokenClass):
             )
             options["user"] = token.user
             options["challenge"] = hexlify_and_unicode(challenge)
-            if token.user.login is None or token.user.login == "":
+            if token.user is None or token.is_orphaned():
                 log.warning(
-                    f"Passkey {token.token.serial} is assigned to a user without a login. Can not be used for authentication!"
+                    f"Passkey {token.token.serial} is unassigned or assigned to orphaned user. Can not be used for authentication!"
                 )
-                reply_dict["message"] = "Passkey is assigned to a user without a login."
+                reply_dict["message"] = (
+                    "Passkey is unassigned or assigned to orphaned user."
+                )
                 return False, reply_dict
 
             try:


### PR DESCRIPTION
Unassigned Passkeys caused an error before, since "user" is already None. Also use the appropriate function for the orphan check. This would simply cause an error for the user logging in (fatal profile exception), so it shouldn't have any security implications.  
Tested orphaned user, unassigned token and normal Passkey login