### PR TITLE
fix(migrations): duplicate constraint on jwt blocklist nonce

### DIFF
--- a/migrations/versions/9cad6f046bd2_.py
+++ b/migrations/versions/9cad6f046bd2_.py
@@ -19,7 +19,7 @@ def upgrade():
     op.create_table(
         "jwt_blacklist",
         sa.Column("expiration", sa.DateTime(), nullable=True),
-        sa.Column("nonce", sa.Unicode(length=128), nullable=False, unique=True),
+        sa.Column("nonce", sa.Unicode(length=128), nullable=False),
         sa.PrimaryKeyConstraint("nonce"),
         mysql_row_format="DYNAMIC",
     )


### PR DESCRIPTION
The primary key constraint already enforces the nonce being unique. This does not cause problems on PostreSQL or MariaDB (which are **soon** the only supported DBs), but on Oracle DB.  
As in my testing this change does not make a difference on MariaDB or PostgreSQL, fix it for the users (which soon need to migrate anyway).