### PR TITLE
feat: catch missing configs early + unit testing the loading

### DIFF
--- a/edumfa/app.py
+++ b/edumfa/app.py
@@ -141,18 +141,19 @@ def create_app(
 
     try:
         # Try to load the given config_file.
-        # If it does not exist, just ignore it.
-        app.config.from_pyfile(config_file, silent=True)
-    except OSError:
+        app.config.from_pyfile(config_file, silent=False)
+    except OSError as exx:
         sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
         sys.stderr.write("  WARNING: edumfa create_app has no access\n")
         sys.stderr.write(f"  to {config_file}!\n")
         sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-
-    # Try to load the file, that was specified in the environment variable
-    # EDUMFA_CONFIG_FILE
-    # If this file does not exist, we create an error!
-    app.config.from_envvar(ENV_KEY, silent=True)
+        raise exx
+    except Exception as exx:
+        sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+        sys.stderr.write(f"  ERROR: edumfa create_app could not read {config_file}!\n")
+        sys.stderr.write(f"  Reason: {exx}\n")
+        sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+        raise exx
 
     # We allow to set different static folders
     app.static_folder = app.config.get("EDUMFA_STATIC_FOLDER", "static/")

--- a/edumfa/app.py
+++ b/edumfa/app.py
@@ -139,21 +139,23 @@ def create_app(
     if config_name:
         app.config.from_object(config[config_name])
 
-    try:
-        # Try to load the given config_file.
-        app.config.from_pyfile(config_file, silent=False)
-    except OSError as exx:
-        sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-        sys.stderr.write("  WARNING: edumfa create_app has no access\n")
-        sys.stderr.write(f"  to {config_file}!\n")
-        sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-        raise exx
-    except Exception as exx:
-        sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-        sys.stderr.write(f"  ERROR: edumfa create_app could not read {config_file}!\n")
-        sys.stderr.write(f"  Reason: {exx}\n")
-        sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-        raise exx
+    
+    if config_file and config_file.strip() != '':
+        try:
+            # Try to load the given config_file.
+            app.config.from_pyfile(config_file, silent=False)
+        except OSError as exx:
+            sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+            sys.stderr.write("  WARNING: edumfa create_app has no access\n")
+            sys.stderr.write(f"  to {config_file}!\n")
+            sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+            raise exx
+        except Exception as exx:
+            sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+            sys.stderr.write(f"  ERROR: edumfa create_app could not read {config_file}!\n")
+            sys.stderr.write(f"  Reason: {exx}\n")
+            sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+            raise exx
 
     # We allow to set different static folders
     app.static_folder = app.config.get("EDUMFA_STATIC_FOLDER", "static/")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,8 +3,10 @@ This testfile tests the basic app functionality of the privacyIDEA app
 """
 
 import inspect
+import io
 import logging
 import os
+import tempfile
 import unittest
 from unittest import mock
 
@@ -111,6 +113,75 @@ class AppTestCase(unittest.TestCase):
             m for m in members if not (m[0].startswith("__") and m[0].endswith("__"))
         ]
         self.assertTrue(all(app.config[k] == v for k, v in conf), app)
+
+    def test_02a_config_file_from_env_is_parsed(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".py") as config_file:
+            config_file.write('EDUMFA_LOGFILE = "env-config.log"\n')
+            config_file.write('EDUMFA_CUSTOM_CSS = "env-custom.css"\n')
+            config_file.flush()
+
+            with mock.patch.dict(os.environ, {"EDUMFA_CONFIGFILE": config_file.name}):
+                app = create_app(config_name="testing", silent=True)
+
+        self.assertEqual(app.config["EDUMFA_LOGFILE"], "env-config.log")
+        self.assertEqual(app.config["EDUMFA_CUSTOM_CSS"], "env-custom.css")
+
+    def test_02b_invalid_config_file_from_env_raises(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".py") as config_file:
+            config_file.write("this is not valid python config\n")
+            config_file.flush()
+
+            stderr = io.StringIO()
+            with mock.patch.dict(os.environ, {"EDUMFA_CONFIGFILE": config_file.name}):
+                with mock.patch("sys.stderr", stderr):
+                    with self.assertRaises(SyntaxError):
+                        create_app(config_name="testing", silent=True)
+
+        output = stderr.getvalue()
+        self.assertIn("ERROR: edumfa create_app could not read", output)
+        self.assertIn(config_file.name, output)
+        self.assertIn("Reason: invalid syntax", output)
+
+    def test_02c_missing_config_file_from_env_raises_verbose(self):
+        with tempfile.TemporaryDirectory() as config_dir:
+            missing_config_file = os.path.join(config_dir, "missing-edumfa.cfg")
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            with mock.patch.dict(os.environ, {"EDUMFA_CONFIGFILE": missing_config_file}):
+                with mock.patch("sys.stdout", stdout), mock.patch("sys.stderr", stderr):
+                    with self.assertRaises(OSError) as cm:
+                        create_app(config_name="testing")
+
+        self.assertIn("Unable to load configuration file", str(cm.exception))
+        self.assertIn(missing_config_file, str(cm.exception))
+        self.assertIn("The configuration name is: testing", stdout.getvalue())
+        self.assertIn(
+            f"Additional configuration will be read from the file {missing_config_file}",
+            stdout.getvalue(),
+        )
+        self.assertIn("WARNING: edumfa create_app has no access", stderr.getvalue())
+        self.assertIn(missing_config_file, stderr.getvalue())
+
+    def test_02d_missing_explicit_config_file_raises(self):
+        with tempfile.TemporaryDirectory() as config_dir:
+            missing_config_file = os.path.join(
+                config_dir, "missing-explicit-edumfa.cfg"
+            )
+            stderr = io.StringIO()
+
+            with mock.patch("sys.stderr", stderr):
+                with self.assertRaises(OSError) as cm:
+                    create_app(
+                        config_name="testing",
+                        config_file=missing_config_file,
+                        silent=True,
+                    )
+
+        self.assertIn("Unable to load configuration file", str(cm.exception))
+        self.assertIn(missing_config_file, str(cm.exception))
+        self.assertIn("WARNING: edumfa create_app has no access", stderr.getvalue())
+        self.assertIn(missing_config_file, stderr.getvalue())
 
     def test_03_logging_config_file(self):
         class Config(TestingConfig):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -3,10 +3,45 @@ import os
 import tempfile
 import unittest
 
+from click.testing import CliRunner
+
 from edumfa.app import create_app
 from edumfa.commands.manage.main import cli as edumfa_manage
 from edumfa.lib.auditmodules.sqlaudit import LogEntry
 from edumfa.models import EventHandler, Policy, db
+
+
+class EduMfaManageStartupTestCase(unittest.TestCase):
+    def test_01_invalid_config_file_from_env_fails_during_app_startup(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".py") as config_file:
+            config_file.write("this is not valid python config\n")
+            config_file.flush()
+
+            result = CliRunner().invoke(
+                edumfa_manage,
+                ["--quiet", "create_enckey"],
+                env={"EDUMFA_CONFIGFILE": config_file.name},
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIsInstance(result.exception, SyntaxError)
+        self.assertIn("ERROR: edumfa create_app could not read", result.output)
+        self.assertIn(config_file.name, result.output)
+        self.assertIn("Reason: invalid syntax", result.output)
+
+    def test_02_missing_config_file_from_env_fails_during_app_startup(self):
+        with tempfile.TemporaryDirectory() as config_dir:
+            missing_config_file = os.path.join(config_dir, "missing-edumfa.cfg")
+            result = CliRunner().invoke(
+                edumfa_manage,
+                ["--quiet", "create_enckey"],
+                env={"EDUMFA_CONFIGFILE": missing_config_file},
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIsInstance(result.exception, OSError)
+        self.assertIn("WARNING: edumfa create_app has no access", result.output)
+        self.assertIn(missing_config_file, result.output)
 
 
 class ScriptsTestCase(unittest.TestCase):


### PR DESCRIPTION
since we are simply mapping the config file path from the env variable we can remove this duplicate code and simply run through the existing code path

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eduMFA/codesmith/eduMFA/pr/1160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783507595&installation_id=137412999&pr_number=1160&repository=eduMFA%2FeduMFA&return_to=https%3A%2F%2Fgithub.com%2FeduMFA%2FeduMFA%2Fpull%2F1160&signature=0d158410ab5e9db45be746365c54cc4a1740479ea9739588feb7010d0af94f45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->