### PR TITLE
fix: fix dangling session on clientapp update fail

### DIFF
--- a/edumfa/models.py
+++ b/edumfa/models.py
@@ -2745,6 +2745,7 @@ class ClientApplication(MethodsMixin, db.Model):
                 ).update(values)
                 db.session.commit()
             except (OperationalError, IntegrityError) as e:
+                db.session.rollback()
                 log.warning(f"Unable to update ClientApplication entry: {e}")
 
     def __repr__(self):


### PR DESCRIPTION
This extends the fix in #1142 in case an existing entry gets updated instead of created.  
Tested saving clientapplications and `/validate/check` on MariaDB and PostgreSQL.  
See the SQLAlchemy documentation why this is necessary: https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#managing-transactions
The flush should already be taken care of with the commit(): https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.commit