### PR TITLE
chore(docs): declare supported db systems

### DIFF
--- a/deploy/docker-example/docker-compose.yml
+++ b/deploy/docker-example/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mariadb:
-    image: docker.io/mariadb:lts-noble
+    image: docker.io/mariadb:11.8
     restart: always
     volumes:
       - mariadb-data:/var/lib/mysql:rw

--- a/doc/faq/mysqldb.rst
+++ b/doc/faq/mysqldb.rst
@@ -4,9 +4,10 @@ Database connect string
 -----------------------
 
 Due to its use of a database abstraction layer, eduMFA can work with several
-databases with the help of corresponding database drivers.
+databases with the help of corresponding database drivers. Please see
+:ref:`choosing_a_database` for supported databases.
 
-The database and corresponding diver are specified in the connect string
+The database and corresponding driver are specified in the connect string
 ``SQLALCHEMY_DATABASE_URI`` in :ref:`cfgfile`
 
 .. _mysqldb:
@@ -37,13 +38,3 @@ the eduMFA virtual environment with::
 The corresponding connect string looks like this:
 
 **connect string**: ``postgresql+psycopg2://<user>:<password>@<host>/<database>``
-
-
-Other databases
-~~~~~~~~~~~~~~~
-
-While we recommend MySQL as the backend database we regularly test MariaDB and
-PostgreSQL as well.
-
-Other databases like Oracle or MSSQL are working as well but not all
-functionality can be assured, so be aware that "Your mileage may vary".

--- a/doc/faq/mysqldb.rst
+++ b/doc/faq/mysqldb.rst
@@ -12,12 +12,15 @@ The database and corresponding driver are specified in the connect string
 
 .. _mysqldb:
 
-MySQL / MariaDB
-~~~~~~~~~~~~~~~
+MariaDB
+~~~~~~~
 
-While there are several database driver packages for MySQL, we recommend *PyMySQL*
-which is a pure Python package and does not require external libraries or a build
-environment on the server.
+While there are several database driver packages for MariaDB, we recommend
+*PyMySQL* which is a pure Python package and does not require external libraries
+or a build environment on the server.
+
+.. note:: While the name contains "MySQL", please note that MySQL (as opposed to
+         MariaDB) is not officially supported by eduMFA.
 
 *PyMySQL* is already installed in the virtual environment as a requirement for
 eduMFA.

--- a/doc/installation/database.rst
+++ b/doc/installation/database.rst
@@ -21,10 +21,6 @@ Notes:
 
 - None
 
-.. TODO: psql's default isolation level is Read Commited
-   (https://www.postgresql.org/docs/current/transaction-iso.html#XACT-READ-COMMITTED)
-   instead of Repeatable Read like in MariaDB. Is this an issue?
-
 MariaDB
 ^^^^^^^
 
@@ -35,8 +31,6 @@ Notes:
 
 - Please make sure that ``innodb_snapshot_isolation`` is enabled. This is the
   default starting from version 11.6.2.
-
-.. TODO: should it specify which isolation level to configure?
 
 Versions
 ^^^^^^^^

--- a/doc/installation/database.rst
+++ b/doc/installation/database.rst
@@ -1,0 +1,64 @@
+.. _choosing_a_database:
+
+Choosing a Database
+--------------------
+
+In order to make sure eduMFA is working smoothly and securely, eduMFA only
+supports certain databases instead of every supported by SQLAlchemy in theory.
+To keep the scope limited, issues and pull requests which are not related to a
+supported database will be closed.
+
+Please choose one of the following databases.
+
+
+PostgreSQL
+^^^^^^^^^^
+
+PostgreSQL is supported in versions 17 and 18. Other versions may work too but
+are not tested.
+
+Notes:
+
+- None
+
+.. TODO: psql's default isolation level is Read Commited
+   (https://www.postgresql.org/docs/current/transaction-iso.html#XACT-READ-COMMITTED)
+   instead of Repeatable Read like in MariaDB. Is this an issue?
+
+MariaDB
+^^^^^^^
+
+MariaDB is supported in version 11.8. Other versions may work too but are not
+tested.
+
+Notes:
+
+- Please make sure that ``innodb_snapshot_isolation`` is enabled. This is the
+  default starting from version 11.6.2.
+- If you are using Galera, avoid using a multi-primary setup. Try to only write
+  to one node at a time.
+
+.. TODO: should it specify which isolation level to configure?
+
+Versions
+^^^^^^^^
+As a rule of thumb, eduMFA will support the following versions:
+
+- the default version of Debian stable
+- the default version of the latest Ubuntu LTS
+- the latest LTS/stable version of the database system itself
+
+Of course, there will be a delay from a release of a new version until it is
+officially listed as supported. Older versions will also not instantly be kicked
+out to allow for a transitory period.
+
+Avoid these databases
+^^^^^^^^^^^^^^^^^^^^^
+Any not listed database might potentially not work. The following databases are
+known to not work without manual intervention at the source level:
+
+- Microsoft SQL Server
+- Oracle Database Server
+
+While SQLite is used for development purposes, it is not recommended for
+productive or testing setups.

--- a/doc/installation/database.rst
+++ b/doc/installation/database.rst
@@ -24,8 +24,8 @@ Notes:
 MariaDB
 ^^^^^^^
 
-MariaDB (also with Galera) is supported in version 11.8. Other versions may work
-too but are not tested.
+MariaDB (also with Galera) is supported in version 11.8 and 12.3. Other versions
+may work too but are not tested.
 
 Notes:
 

--- a/doc/installation/database.rst
+++ b/doc/installation/database.rst
@@ -28,15 +28,13 @@ Notes:
 MariaDB
 ^^^^^^^
 
-MariaDB is supported in version 11.8. Other versions may work too but are not
-tested.
+MariaDB (also with Galera) is supported in version 11.8. Other versions may work
+too but are not tested.
 
 Notes:
 
 - Please make sure that ``innodb_snapshot_isolation`` is enabled. This is the
   default starting from version 11.6.2.
-- If you are using Galera, avoid using a multi-primary setup. Try to only write
-  to one node at a time.
 
 .. TODO: should it specify which isolation level to configure?
 
@@ -51,14 +49,3 @@ As a rule of thumb, eduMFA will support the following versions:
 Of course, there will be a delay from a release of a new version until it is
 officially listed as supported. Older versions will also not instantly be kicked
 out to allow for a transitory period.
-
-Avoid these databases
-^^^^^^^^^^^^^^^^^^^^^
-Any not listed database might potentially not work. The following databases are
-known to not work without manual intervention at the source level:
-
-- Microsoft SQL Server
-- Oracle Database Server
-
-While SQLite is used for development purposes, it is not recommended for
-productive or testing setups.

--- a/doc/installation/database.rst
+++ b/doc/installation/database.rst
@@ -24,8 +24,8 @@ Notes:
 MariaDB
 ^^^^^^^
 
-MariaDB (also with Galera) is supported in version 11.8 and 12.3. Other versions
-may work too but are not tested.
+MariaDB (also with Galera in a multi-primary configuration) is supported in
+version 11.8 and 12.3. Other versions may work too but are not tested.
 
 Notes:
 

--- a/doc/installation/docker.rst
+++ b/doc/installation/docker.rst
@@ -32,7 +32,7 @@ The container contains a default logging configuration printing the logs to `std
 
    services:
      mariadb:
-       image: docker.io/mariadb:lts-noble
+       image: docker.io/mariadb:11.8
        restart: always
        volumes:
          - mariadb-data:/var/lib/mysql:rw

--- a/doc/installation/docker.rst
+++ b/doc/installation/docker.rst
@@ -15,6 +15,11 @@ Before proceeding, ensure that you have:
 1. Docker installed on your system
 2. Access to GitHub Registry
 
+The example below shows a possible configuration with a MariaDB inside the same
+compose file. You could also use an external or different database.  
+For supported database systems and their versions, please see
+:ref:`choosing_a_database`.
+
 
 Docker Compose
 ..............
@@ -90,7 +95,7 @@ The `.env` file should contain the following variables:
 - EDUMFA_LOGO: filename of custom logo (optional)
 - EDUMFA_PAGE_TITLE: custom page title (optional)
 
-You can also add a "_FILE" suffix to each variable name and pass a path to read the value from a file instead. For example instead of passing `SECRET_KEY`:
+You can also add a "_FILE" suffix to each variable name and pass a path to read the value from a file instead. For example instead of passing ``SECRET_KEY``:
 
 .. code-block:: bash
 

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -16,6 +16,7 @@ If you want to upgrade please read :ref:`upgrade`.
 .. toctree::
    :maxdepth: 1
 
+   database
    pip
    ubuntu
    docker

--- a/doc/installation/pip.rst
+++ b/doc/installation/pip.rst
@@ -53,23 +53,13 @@ Configuration
 Database
 ^^^^^^^^
 
-eduMFA makes use of `SQLAlchemy <https://www.sqlalchemy.org>`_ to be able
-to talk to different SQL-based databases. Our best experience is with
-`MySQL <https://www.mysql.com/>`_ but SQLAlchemy supports many different
-databases [#sqlaDialects]_.
+Please refer to :ref:`choosing_a_database`. Create a database, as well as a user
+with full permissions to that database.
 
 The database server should be installed on the host or be otherwise reachable.
 
-In order for eduMFA to use the database, a database user with the
-appropriate privileges is needed.
-The following SQL commands will create the database as well as a user in `MySQL`::
-
-    CREATE DATABASE edumfa;
-    CREATE USER "edumfa"@"localhost" IDENTIFIED BY "<dbsecret>";
-    GRANT ALL PRIVILEGES ON edumfa.* TO "edumfa"@"localhost";
-
-You must then add the database name, user and password to your `edumfa.cfg`. See
-:ref:`cfgfile` for more information on the configuration.
+You must then add the database name, user and password to your ``edumfa.cfg``.
+See :ref:`cfgfile` for more information on the configuration.
 
 Setting up eduMFA
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/installation/pip.rst
+++ b/doc/installation/pip.rst
@@ -104,8 +104,3 @@ is needed.
 Setup and configuration of a webserver can be a complex procedure depending on
 several parameter (host OS, SSL, internal network structure, ...).
 More on the WSGI setup for eduMFA can be found in :ref:`wsgiscript`.
-
-
-.. rubric:: Footnotes
-
-.. [#sqlaDialects] https://docs.sqlalchemy.org/en/14/dialects/index.html


### PR DESCRIPTION
In effect, eduMFA already has supported database systems: those we can test and therefore merge fixes for. This currently is not communicated effectively: PRs like #734 seem proper and ready to merge, but (due to missing development systems) are left to sit.  
Also looking at the recent security fixes in v2.9.2, the fine-grained behaviour of the database systems are relevant to ensure a secure system. Due to not having unlimited resources, this means narrowing down the scope.  

~~This PR is a **work in progess** to communicate the database systems which are supported.~~ Its core purpose is communicating what is already the case. The version definition goes a little beyond that, however is relevant in retrospect to the replayability issues.  

NOTE: This does not affect the SQL resolver! This is just about the database eduMFA uses for its own data.

TODO

- [x] decide whether this is the policy going forward
- [x] update docker.html and docker-example to use a supported db version
- [x] add the versions to the new DB test matrix
- [x] https://github.com/eduMFA/eduMFA/pull/1183/changes mysql faq; container; database.html
- [x] fix merge conflict
- [x] wait for #1256 to get merged

resolves #1150
