### PR TITLE
feat(webui): offer select_manually as a node for periodictasks

### DIFF
--- a/doc/periodictask/index.rst
+++ b/doc/periodictask/index.rst
@@ -57,10 +57,11 @@ Every periodic task has the following attributes:
 	propagating the database changes to the other node). The name of the local node
 	as well as the names of remote nodes are configured in :ref:`cfgfile`.
 
-	Additionally, there is an option "select_manually". This option is
-	useful in case node names are unpredictable (like when used in a
-	Kubernetes deployment). In that case ``--node select_manually`` must be
-	passed to ``edumfa-cron``.
+	Additionally, there is a special option "select_manually" in the list of
+	nodes. This option is useful in case node names are unpredictable (like
+	when used in a Kubernetes deployment). If "select_manually" is ticked,
+	the task will run where ``edumfa-cron run_scheduled`` is executed with
+	the ``--node select_manually`` parameter.
 
 **taskmodule**
 	The task module determines the actual activity of the task. eduMFA comes

--- a/doc/periodictask/index.rst
+++ b/doc/periodictask/index.rst
@@ -57,6 +57,11 @@ Every periodic task has the following attributes:
 	propagating the database changes to the other node). The name of the local node
 	as well as the names of remote nodes are configured in :ref:`cfgfile`.
 
+	Additionally, there is an option "select_manually". This option is
+	useful in case node names are unpredictable (like when used in a
+	Kubernetes deployment). In that case ``--node select_manually`` must be
+	passed to ``edumfa-cron``.
+
 **taskmodule**
 	The task module determines the actual activity of the task. eduMFA comes
 	with several task modules, see :ref:`periodic_task_modules`.

--- a/edumfa/static/components/config/controllers/periodicTaskController.js
+++ b/edumfa/static/components/config/controllers/periodicTaskController.js
@@ -94,6 +94,10 @@ myApp.controller("periodicTaskDetailController", ["$scope", "$stateParams",
         ConfigFactory.getNodes(function(response) {
             // prepare the input model for the multi-select box
             $scope.availableNodes = [];
+            $scope.availableNodes.push({
+                "name": "select_manually",
+                "ticked": false,
+            });
             angular.forEach(response.result.value, function (node) {
                 $scope.availableNodes.push({
                     "name": node,


### PR DESCRIPTION
Periodic tasks have to specify a node to run on. This list is taken from two sources: the current `EDUMFA_NODE` and `EDUMFA_NODES`.  
In the Helm chart, cronjobs don't run on a node, a new container gets spawned to run the task. A workaround right now would be to specify some kind of placeholder in `EDUMFA_NODES`, but this does not seem like the correct way to approach this as it would not actually be an eduMFA node.  

Instead, this patch does it the other way around: it offers a "synthetic" option which then can be used with a manual override. It might also ease configuration outside of Helm for certain requirements.