### PR TITLE
feat(image): support different audit keys and encfile paths

### DIFF
--- a/deploy/docker/edumfa_config.py
+++ b/deploy/docker/edumfa_config.py
@@ -55,9 +55,9 @@ SQLALCHEMY_DATABASE_URI = f"{get_var('DB_DRIVER')}://{get_var('DB_USER')}:{get_v
 SUPERUSER_REALM = get_var("SUPERUSER_REALM", "super,administrators").split(",")
 SECRET_KEY = get_var("SECRET_KEY")
 EDUMFA_PEPPER = get_var("EDUMFA_PEPPER")
-EDUMFA_ENCFILE = "/etc/edumfa/enckey"
-EDUMFA_AUDIT_KEY_PRIVATE = "/etc/edumfa/private.pem"
-EDUMFA_AUDIT_KEY_PUBLIC = "/etc/edumfa/public.pem"
+EDUMFA_ENCFILE = get_var("EDUMFA_ENCFILE", "/etc/edumfa/enckey")
+EDUMFA_AUDIT_KEY_PRIVATE = get_var("EDUMFA_AUDIT_KEY_PRIVATE", "/etc/edumfa/private.pem")
+EDUMFA_AUDIT_KEY_PUBLIC = get_var("EDUMFA_AUDIT_KEY_PUBLIC", "/etc/edumfa/public.pem")
 EDUMFA_LOGFILE = "/var/log/edumfa/edumfa.log"
 EDUMFA_LOGCONFIG = get_var("EDUMFA_LOGCONFIG", "/opt/edumfa/logging.yml")
 EDUMFA_UI_DEACTIVATED = get_var("EDUMFA_UI_DEACTIVATED", "False") == "True"

--- a/doc/installation/docker.rst
+++ b/doc/installation/docker.rst
@@ -78,6 +78,9 @@ The `.env` file should contain the following variables:
 - MARIADB_ROOT_PASSWORD: the MariaDB root password (not used by eduMFA, required)
 - EDUMFA_SECRET_KEY: the secret key which signs API tokens, should be at least 24 random characters long
 - EDUMFA_PEPPER: the pepper to use for password hashing, should be at least 24 random characters long
+- EDUMFA_AUDIT_KEY_PRIVATE: an alternative path to the audit key (optional, default: ``/etc/edumfa/private.pem``)
+- EDUMFA_AUDIT_KEY_PUBLIC: an alternative path to the audit certificate (optional, default: ``/etc/edumfa/public.pem``)
+- EDUMFA_ENCFILE: an alternative path to the enckey (optional, default: ``/etc/edumfa/enckey``)
 - EDUMFA_ADMIN_USER: the username for the local eduMFA admin (optional)
 - EDUMFA_ADMIN_PASS: the password for the local eduMFA admin (optional)
 - EDUMFA_LOGCONFIG: a path to an alternative logging config (optional)


### PR DESCRIPTION
Support different paths for credential files. This makes the Helm chart a little more maintainable.