### PR TITLE
chore(image): remove superfluous line

### DIFF
--- a/deploy/docker/edumfa_config.py
+++ b/deploy/docker/edumfa_config.py
@@ -58,7 +58,6 @@ EDUMFA_PEPPER = get_var("EDUMFA_PEPPER")
 EDUMFA_ENCFILE = "/etc/edumfa/enckey"
 EDUMFA_AUDIT_KEY_PRIVATE = "/etc/edumfa/private.pem"
 EDUMFA_AUDIT_KEY_PUBLIC = "/etc/edumfa/public.pem"
-EDUMFA_LOGFILE = "/var/log/edumfa/edumfa.log"
 EDUMFA_LOGCONFIG = get_var("EDUMFA_LOGCONFIG", "/opt/edumfa/logging.yml")
 EDUMFA_UI_DEACTIVATED = get_var("EDUMFA_UI_DEACTIVATED", "False") == "True"
 EDUMFA_AUDIT_SQL_TRUNCATE = True


### PR DESCRIPTION
There is no logging to a file left in the default configuration. If users want to log to a file, they have to create a logging config anyhow.