### PR TITLE
chore(ci): test supported db versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,19 +51,40 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - database: postgres-psycopg2
+          - database: postgres-17-psycopg2
+            image: postgres:17-alpine
+            port: 5432
+            test_database_url: postgresql+psycopg2://edumfa:edumfa@127.0.0.1:5432/edumfa
+            health_cmd: pg_isready -U edumfa -d edumfa
+            extra_sync_args: "--extra postgres"
+            system_deps: "libpq-dev"
+          - database: postgres-18-psycopg2
             image: postgres:18-alpine
             port: 5432
             test_database_url: postgresql+psycopg2://edumfa:edumfa@127.0.0.1:5432/edumfa
             health_cmd: pg_isready -U edumfa -d edumfa
             extra_sync_args: "--extra postgres"
             system_deps: "libpq-dev"
-          - database: mariadb
+          - database: mariadb-11.5
             # MariaDB version 11.5 should continue be tested for the foreseeable
             # future, as that version is vulnerable to
             # https://github.com/advisories/GHSA-qq2p-4282-cfc5 and testing with
             # it therefore makes sure the replayability fix keeps working.
             image: mariadb:11.5
+            port: 3306
+            test_database_url: mysql+pymysql://edumfa:edumfa@127.0.0.1:3306/edumfa
+            health_cmd: mariadb-admin ping -h 127.0.0.1 -uedumfa -pedumfa
+            extra_sync_args: ""
+            system_deps: ""
+          - database: mariadb-11.8
+            image: mariadb:11.8
+            port: 3306
+            test_database_url: mysql+pymysql://edumfa:edumfa@127.0.0.1:3306/edumfa
+            health_cmd: mariadb-admin ping -h 127.0.0.1 -uedumfa -pedumfa
+            extra_sync_args: ""
+            system_deps: ""
+          - database: mariadb-12.3
+            image: mariadb:12.3
             port: 3306
             test_database_url: mysql+pymysql://edumfa:edumfa@127.0.0.1:3306/edumfa
             health_cmd: mariadb-admin ping -h 127.0.0.1 -uedumfa -pedumfa


### PR DESCRIPTION
Adds the versions which were determined in #1163 to be supported DBs to the test matrix.