### PR TITLE
feat: add an (unauthenticated) health check endpoint

### DIFF
--- a/edumfa/api/health.py
+++ b/edumfa/api/health.py
@@ -27,8 +27,8 @@ from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
 from flask import Blueprint, Response, jsonify, request
-from sqlalchemy import text
 
+from edumfa.lib.sqlutils import is_db_available
 from edumfa.models import db
 
 health_blueprint = Blueprint("health_blueprint", __name__)
@@ -66,14 +66,6 @@ def _get_database_schema_head(connection) -> str | None:
     return context.get_current_revision()
 
 
-def _check_database(connection) -> dict[str, str]:
-    """
-    Check whether a simple query can be executed against the database.
-    """
-    connection.execute(text("SELECT 1"))
-    return {"status": "ok"}
-
-
 def _check_schema(connection) -> dict[str, str | None]:
     """
     Check whether the database schema revision matches the application migrations.
@@ -91,24 +83,30 @@ def _check_schema(connection) -> dict[str, str | None]:
     return result
 
 
-def _health_response(check_schema: bool = False) -> tuple[object, int]:
+def _health_response(check_schema: bool = False) -> tuple[Response, int]:
     """
     Build the readiness response and HTTP status code from the configured checks.
     """
     status_code = 200
     checks: dict[str, dict[str, str | None]] = {}
+    database_available = is_db_available(db.engine)
+
+    if database_available:
+        checks["database"] = {"status": "ok"}
+    else:
+        checks["database"] = {
+            "status": "error",
+            "message": "Database connection check failed",
+        }
+        return jsonify({"status": "error", "checks": checks}), 503
 
     try:
-        with db.engine.connect() as connection:
-            checks["database"] = _check_database(connection)
-            if check_schema:
+        if check_schema:
+            with db.engine.connect() as connection:
                 checks["schema"] = _check_schema(connection)
     except Exception as exx:
         status_code = 503
-        if "database" not in checks:
-            checks["database"] = {"status": "error", "message": str(exx)}
-        elif check_schema:
-            checks["schema"] = {"status": "error", "message": str(exx)}
+        checks["schema"] = {"status": "error", "message": str(exx)}
 
     if any(check["status"] != "ok" for check in checks.values()):
         status_code = 503
@@ -134,7 +132,7 @@ def live() -> Response:
 
 
 @health_blueprint.route("/ready", methods=["GET"])
-def ready() -> Response:
+def ready() -> tuple[Response, int]:
     """
     Return readiness based on database availability and optional schema state.
     """

--- a/edumfa/api/health.py
+++ b/edumfa/api/health.py
@@ -1,0 +1,116 @@
+#
+# License:  AGPLv3
+# This file is part of eduMFA. eduMFA is a fork of privacyIDEA which was forked from LinOTP.
+# Copyright (c) 2026 eduMFA Project-Team
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Unauthenticated health endpoints for load balancers and orchestration probes like kubernetes, haproxy, nginx or docker.
+"""
+
+from pathlib import Path
+from sysconfig import get_paths
+
+from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from flask import Blueprint, jsonify, request
+from sqlalchemy import text
+
+from edumfa.models import db
+
+health_blueprint = Blueprint("health_blueprint", __name__)
+
+
+def _migration_directory():
+    candidates = [
+        Path(__file__).resolve().parents[2] / "migrations",
+        Path(get_paths()["data"]) / "lib" / "edumfa" / "migrations",
+    ]
+    for candidate in candidates:
+        if (candidate / "env.py").is_file() and (candidate / "versions").is_dir():
+            return candidate
+    raise FileNotFoundError("Could not find eduMFA migration directory")
+
+
+def _get_required_schema_heads():
+    migrations = _migration_directory()
+    config = Config(str(migrations / "alembic.ini"))
+    config.set_main_option("script_location", str(migrations))
+    return sorted(ScriptDirectory.from_config(config).get_heads())
+
+
+def _get_database_schema_heads(connection):
+    context = MigrationContext.configure(connection)
+    return sorted(context.get_current_heads())
+
+
+def _check_database(connection):
+    connection.execute(text("SELECT 1"))
+    return {"status": "ok"}
+
+
+def _check_schema(connection):
+    required_heads = _get_required_schema_heads()
+    current_heads = _get_database_schema_heads(connection)
+    result = {
+        "status": "ok",
+        "current": current_heads,
+        "required": required_heads,
+    }
+    if current_heads != required_heads:
+        result["status"] = "error"
+        result["message"] = "Database schema revision does not match application migrations"
+    return result
+
+
+def _health_response(check_schema=False):
+    status_code = 200
+    checks = {}
+
+    try:
+        with db.engine.connect() as connection:
+            checks["database"] = _check_database(connection)
+            if check_schema:
+                checks["schema"] = _check_schema(connection)
+    except Exception as exx:
+        status_code = 503
+        if "database" not in checks:
+            checks["database"] = {"status": "error", "message": str(exx)}
+        elif check_schema:
+            checks["schema"] = {"status": "error", "message": str(exx)}
+
+    if any(check["status"] != "ok" for check in checks.values()):
+        status_code = 503
+
+    status = "ok" if status_code == 200 else "error"
+    return jsonify({"status": status, "checks": checks}), status_code
+
+
+def _check_schema_requested():
+    value = request.args.get("schema", "false").lower()
+    return value.lower() in {"1", "true"}
+
+
+@health_blueprint.route("/live", methods=["GET"])
+def live():
+    return jsonify({"status": "ok"})
+
+
+@health_blueprint.route("", methods=["GET"])
+@health_blueprint.route("/", methods=["GET"])
+@health_blueprint.route("/ready", methods=["GET"])
+def ready():
+    return _health_response(check_schema=_check_schema_requested())

--- a/edumfa/api/health.py
+++ b/edumfa/api/health.py
@@ -26,7 +26,7 @@ from sysconfig import get_paths
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, Response, jsonify, request
 from sqlalchemy import text
 
 from edumfa.models import db
@@ -34,7 +34,10 @@ from edumfa.models import db
 health_blueprint = Blueprint("health_blueprint", __name__)
 
 
-def _migration_directory():
+def _migration_directory() -> Path:
+    """
+    Return the migration directory used by the running eduMFA installation.
+    """
     candidates = [
         Path(__file__).resolve().parents[2] / "migrations",
         Path(get_paths()["data"]) / "lib" / "edumfa" / "migrations",
@@ -45,40 +48,55 @@ def _migration_directory():
     raise FileNotFoundError("Could not find eduMFA migration directory")
 
 
-def _get_required_schema_heads():
+def _get_required_schema_head() -> str | None:
+    """
+    Return the migration revision expected by this application version.
+    """
     migrations = _migration_directory()
     config = Config(str(migrations / "alembic.ini"))
     config.set_main_option("script_location", str(migrations))
-    return sorted(ScriptDirectory.from_config(config).get_heads())
+    return ScriptDirectory.from_config(config).get_current_head()
 
 
-def _get_database_schema_heads(connection):
+def _get_database_schema_head(connection) -> str | None:
+    """
+    Return the migration revision currently recorded in the database.
+    """
     context = MigrationContext.configure(connection)
-    return sorted(context.get_current_heads())
+    return context.get_current_revision()
 
 
-def _check_database(connection):
+def _check_database(connection) -> dict[str, str]:
+    """
+    Check whether a simple query can be executed against the database.
+    """
     connection.execute(text("SELECT 1"))
     return {"status": "ok"}
 
 
-def _check_schema(connection):
-    required_heads = _get_required_schema_heads()
-    current_heads = _get_database_schema_heads(connection)
+def _check_schema(connection) -> dict[str, str | None]:
+    """
+    Check whether the database schema revision matches the application migrations.
+    """
+    required_head = _get_required_schema_head()
+    current_head = _get_database_schema_head(connection)
     result = {
         "status": "ok",
-        "current": current_heads,
-        "required": required_heads,
+        "current": current_head,
+        "required": required_head,
     }
-    if current_heads != required_heads:
+    if current_head != required_head:
         result["status"] = "error"
         result["message"] = "Database schema revision does not match application migrations"
     return result
 
 
-def _health_response(check_schema=False):
+def _health_response(check_schema: bool = False) -> tuple[object, int]:
+    """
+    Build the readiness response and HTTP status code from the configured checks.
+    """
     status_code = 200
-    checks = {}
+    checks: dict[str, dict[str, str | None]] = {}
 
     try:
         with db.engine.connect() as connection:
@@ -99,18 +117,25 @@ def _health_response(check_schema=False):
     return jsonify({"status": status, "checks": checks}), status_code
 
 
-def _check_schema_requested():
+def _check_schema_requested() -> bool:
+    """
+    Return whether the request asked to include the schema revision check.
+    """
     value = request.args.get("schema", "false").lower()
     return value.lower() in {"1", "true"}
 
 
 @health_blueprint.route("/live", methods=["GET"])
-def live():
+def live() -> Response:
+    """
+    Return a minimal liveness response without checking dependencies.
+    """
     return jsonify({"status": "ok"})
 
 
-@health_blueprint.route("", methods=["GET"])
-@health_blueprint.route("/", methods=["GET"])
 @health_blueprint.route("/ready", methods=["GET"])
-def ready():
+def ready() -> Response:
+    """
+    Return readiness based on database availability and optional schema state.
+    """
     return _health_response(check_schema=_check_schema_requested())

--- a/edumfa/api/health.py
+++ b/edumfa/api/health.py
@@ -20,12 +20,6 @@
 Unauthenticated health endpoints for load balancers and orchestration probes like kubernetes, haproxy, nginx or docker.
 """
 
-from pathlib import Path
-from sysconfig import get_paths
-
-from alembic.config import Config
-from alembic.runtime.migration import MigrationContext
-from alembic.script import ScriptDirectory
 from flask import Blueprint, Response, jsonify, request
 
 from edumfa.lib.sqlutils import is_db_available
@@ -34,93 +28,16 @@ from edumfa.models import db
 health_blueprint = Blueprint("health_blueprint", __name__)
 
 
-def _migration_directory() -> Path:
-    """
-    Return the migration directory used by the running eduMFA installation.
-    """
-    candidates = [
-        Path(__file__).resolve().parents[2] / "migrations",
-        Path(get_paths()["data"]) / "lib" / "edumfa" / "migrations",
-    ]
-    for candidate in candidates:
-        if (candidate / "env.py").is_file() and (candidate / "versions").is_dir():
-            return candidate
-    raise FileNotFoundError("Could not find eduMFA migration directory")
-
-
-def _get_required_schema_head() -> str | None:
-    """
-    Return the migration revision expected by this application version.
-    """
-    migrations = _migration_directory()
-    config = Config(str(migrations / "alembic.ini"))
-    config.set_main_option("script_location", str(migrations))
-    return ScriptDirectory.from_config(config).get_current_head()
-
-
-def _get_database_schema_head(connection) -> str | None:
-    """
-    Return the migration revision currently recorded in the database.
-    """
-    context = MigrationContext.configure(connection)
-    return context.get_current_revision()
-
-
-def _check_schema(connection) -> dict[str, str | None]:
-    """
-    Check whether the database schema revision matches the application migrations.
-    """
-    required_head = _get_required_schema_head()
-    current_head = _get_database_schema_head(connection)
-    result = {
-        "status": "ok",
-        "current": current_head,
-        "required": required_head,
-    }
-    if current_head != required_head:
-        result["status"] = "error"
-        result["message"] = "Database schema revision does not match application migrations"
-    return result
-
-
-def _health_response(check_schema: bool = False) -> tuple[Response, int]:
+def _health_response() -> tuple[Response, int]:
     """
     Build the readiness response and HTTP status code from the configured checks.
     """
-    status_code = 200
     checks: dict[str, dict[str, str | None]] = {}
     database_available = is_db_available(db.engine)
 
     if database_available:
-        checks["database"] = {"status": "ok"}
-    else:
-        checks["database"] = {
-            "status": "error",
-            "message": "Database connection check failed",
-        }
-        return jsonify({"status": "error", "checks": checks}), 503
-
-    try:
-        if check_schema:
-            with db.engine.connect() as connection:
-                checks["schema"] = _check_schema(connection)
-    except Exception as exx:
-        status_code = 503
-        checks["schema"] = {"status": "error", "message": str(exx)}
-
-    if any(check["status"] != "ok" for check in checks.values()):
-        status_code = 503
-
-    status = "ok" if status_code == 200 else "error"
-    return jsonify({"status": status, "checks": checks}), status_code
-
-
-def _check_schema_requested() -> bool:
-    """
-    Return whether the request asked to include the schema revision check.
-    """
-    value = request.args.get("schema", "false").lower()
-    return value.lower() in {"1", "true"}
+        return jsonify({"status": "ok"}), 200
+    return jsonify({"status": "error"}), 503
 
 
 @health_blueprint.route("/live", methods=["GET"])
@@ -134,6 +51,6 @@ def live() -> Response:
 @health_blueprint.route("/ready", methods=["GET"])
 def ready() -> tuple[Response, int]:
     """
-    Return readiness based on database availability and optional schema state.
+    Return readiness based on database availability.
     """
-    return _health_response(check_schema=_check_schema_requested())
+    return _health_response()

--- a/edumfa/api/health.py
+++ b/edumfa/api/health.py
@@ -20,7 +20,7 @@
 Unauthenticated health endpoints for load balancers and orchestration probes like kubernetes, haproxy, nginx or docker.
 """
 
-from flask import Blueprint, Response, jsonify, request
+from flask import Blueprint, Response, jsonify
 
 from edumfa.lib.sqlutils import is_db_available
 from edumfa.models import db

--- a/edumfa/api/health.py
+++ b/edumfa/api/health.py
@@ -32,7 +32,6 @@ def _health_response() -> tuple[Response, int]:
     """
     Build the readiness response and HTTP status code from the configured checks.
     """
-    checks: dict[str, dict[str, str | None]] = {}
     database_available = is_db_available(db.engine)
 
     if database_available:

--- a/edumfa/api/health.py
+++ b/edumfa/api/health.py
@@ -28,17 +28,6 @@ from edumfa.models import db
 health_blueprint = Blueprint("health_blueprint", __name__)
 
 
-def _health_response() -> tuple[Response, int]:
-    """
-    Build the readiness response and HTTP status code from the configured checks.
-    """
-    database_available = is_db_available(db.engine)
-
-    if database_available:
-        return jsonify({"status": "ok"}), 200
-    return jsonify({"status": "error"}), 503
-
-
 @health_blueprint.route("/live", methods=["GET"])
 def live() -> Response:
     """
@@ -52,4 +41,8 @@ def ready() -> tuple[Response, int]:
     """
     Return readiness based on database availability.
     """
-    return _health_response()
+    database_available = is_db_available(db.engine)
+
+    if database_available:
+        return jsonify({"status": "ok"}), 200
+    return jsonify({"status": "error"}), 503

--- a/edumfa/app.py
+++ b/edumfa/app.py
@@ -41,6 +41,7 @@ from edumfa.api.caconnector import caconnector_blueprint
 from edumfa.api.clienttype import client_blueprint
 from edumfa.api.edumfaserver import edumfaserver_blueprint
 from edumfa.api.event import eventhandling_blueprint
+from edumfa.api.health import health_blueprint
 from edumfa.api.machine import machine_blueprint
 from edumfa.api.machineresolver import machineresolver_blueprint
 from edumfa.api.monitoring import monitoring_blueprint
@@ -187,6 +188,7 @@ def create_app(
     app.register_blueprint(monitoring_blueprint, url_prefix="/monitoring")
     app.register_blueprint(tokengroup_blueprint, url_prefix="/tokengroup")
     app.register_blueprint(serviceid_blueprint, url_prefix="/serviceid")
+    app.register_blueprint(health_blueprint, url_prefix="/health")
     db.init_app(app)
     if not script:
         migrate = Migrate(app, db)

--- a/edumfa/app.py
+++ b/edumfa/app.py
@@ -41,6 +41,7 @@ from edumfa.api.caconnector import caconnector_blueprint
 from edumfa.api.clienttype import client_blueprint
 from edumfa.api.edumfaserver import edumfaserver_blueprint
 from edumfa.api.event import eventhandling_blueprint
+from edumfa.api.health import health_blueprint
 from edumfa.api.machine import machine_blueprint
 from edumfa.api.machineresolver import machineresolver_blueprint
 from edumfa.api.monitoring import monitoring_blueprint, stats_blueprint
@@ -188,6 +189,7 @@ def create_app(
     app.register_blueprint(stats_blueprint, url_prefix="/stats")
     app.register_blueprint(tokengroup_blueprint, url_prefix="/tokengroup")
     app.register_blueprint(serviceid_blueprint, url_prefix="/serviceid")
+    app.register_blueprint(health_blueprint, url_prefix="/health")
     db.init_app(app)
     if not script:
         migrate = Migrate(app, db)

--- a/edumfa/commands/manage/core.py
+++ b/edumfa/commands/manage/core.py
@@ -33,7 +33,7 @@ from flask.cli import AppGroup
 from flask_migrate import stamp as f_stamp
 
 from edumfa.lib.security.default import DefaultSecurityModule
-from edumfa.lib.sqlutils import is_db_stamped
+from edumfa.lib.sqlutils import is_db_available, is_db_stamped
 from edumfa.models import db
 
 core_cli = AppGroup("core", help="Core commands")
@@ -254,21 +254,15 @@ def wait_for_db(attempts: int, sleep: int) -> None:
     """
     import time
 
-    from sqlalchemy import text
-    from sqlalchemy.exc import OperationalError
-
     for attempt in range(attempts):
-        try:
-            with db.engine.connect() as connection:
-                connection.execute(text("SELECT 1"))
+        if is_db_available(db.engine):
             click.echo("Database connection successful.")
             return
-        except OperationalError:
-            click.echo(
-                f"Failed to connect to database. Attempt {attempt + 1} of {attempts}. Waiting {sleep} seconds...",
-                err=True,
-            )
-            time.sleep(sleep)
+        click.echo(
+            f"Failed to connect to database. Attempt {attempt + 1} of {attempts}. Waiting {sleep} seconds...",
+            err=True,
+        )
+        time.sleep(sleep)
 
     click.echo(f"Could not connect to the database after {attempts} attempts.")
     sys.exit(1)

--- a/edumfa/lib/sqlutils.py
+++ b/edumfa/lib/sqlutils.py
@@ -22,6 +22,7 @@
 
 from sqlalchemy import MetaData, Table, inspect, select, text
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.expression import ClauseElement, Delete
@@ -122,6 +123,21 @@ def delete_matching_rows(session, table, filter, chunksize=None):
         return result.rowcount
     else:
         return delete_chunked(session, table, filter, chunksize)
+
+
+def is_db_available(engine: Engine) -> bool:
+    """
+    Returns whether the database engine can connect and execute a simple query.
+
+    :param engine: The SQLAlchemy engine object for the database.
+    :return: True if the query succeeds, otherwise False.
+    """
+    try:
+        with engine.connect() as connection:
+            connection.execute(text("SELECT 1"))
+    except SQLAlchemyError:
+        return False
+    return True
 
 
 def is_db_stamped(engine: Engine) -> bool:

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,0 +1,61 @@
+from sqlalchemy import text
+
+from edumfa.api.health import _get_required_schema_heads
+from edumfa.models import db
+
+from .base import MyTestCase
+
+
+class APIHealthTestCase(MyTestCase):
+    def _set_schema_heads(self, heads):
+        db.session.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS alembic_version ("
+                "version_num VARCHAR(32) NOT NULL, "
+                "CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num))"
+            )
+        )
+        db.session.execute(text("DELETE FROM alembic_version"))
+        for head in heads:
+            db.session.execute(
+                text("INSERT INTO alembic_version (version_num) VALUES (:head)"),
+                {"head": head},
+            )
+        db.session.commit()
+
+    def test_00_live_health_is_unauthenticated(self):
+        with self.app.test_request_context("/health/live", method="GET"):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res.data)
+            self.assertEqual({"status": "ok"}, res.json)
+
+    def test_01_ready_health_checks_database(self):
+        with self.app.test_request_context("/health/ready", method="GET"):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res.data)
+            self.assertEqual("ok", res.json["status"])
+            self.assertEqual("ok", res.json["checks"]["database"]["status"])
+            self.assertNotIn("schema", res.json["checks"])
+
+    def test_02_ready_health_checks_schema_when_requested(self):
+        required_heads = _get_required_schema_heads()
+        self._set_schema_heads(required_heads)
+
+        with self.app.test_request_context("/health/ready?schema=true", method="GET"):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res.data)
+            self.assertEqual("ok", res.json["status"])
+            self.assertEqual("ok", res.json["checks"]["database"]["status"])
+            self.assertEqual("ok", res.json["checks"]["schema"]["status"])
+            self.assertEqual(required_heads, res.json["checks"]["schema"]["required"])
+            self.assertEqual(required_heads, res.json["checks"]["schema"]["current"])
+
+    def test_03_health_reports_schema_mismatch_when_requested(self):
+        self._set_schema_heads(["wrong_revision"])
+
+        with self.app.test_request_context("/health?schema=true", method="GET"):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(503, res.status_code, res.data)
+            self.assertEqual("error", res.json["status"])
+            self.assertEqual("ok", res.json["checks"]["database"]["status"])
+            self.assertEqual("error", res.json["checks"]["schema"]["status"])

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,13 +1,13 @@
 from sqlalchemy import text
 
-from edumfa.api.health import _get_required_schema_heads
+from edumfa.api.health import _get_required_schema_head
 from edumfa.models import db
 
 from .base import MyTestCase
 
 
 class APIHealthTestCase(MyTestCase):
-    def _set_schema_heads(self, heads):
+    def _set_schema_head(self, head):
         db.session.execute(
             text(
                 "CREATE TABLE IF NOT EXISTS alembic_version ("
@@ -16,11 +16,10 @@ class APIHealthTestCase(MyTestCase):
             )
         )
         db.session.execute(text("DELETE FROM alembic_version"))
-        for head in heads:
-            db.session.execute(
-                text("INSERT INTO alembic_version (version_num) VALUES (:head)"),
-                {"head": head},
-            )
+        db.session.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES (:head)"),
+            {"head": head},
+        )
         db.session.commit()
 
     def test_00_live_health_is_unauthenticated(self):
@@ -38,8 +37,8 @@ class APIHealthTestCase(MyTestCase):
             self.assertNotIn("schema", res.json["checks"])
 
     def test_02_ready_health_checks_schema_when_requested(self):
-        required_heads = _get_required_schema_heads()
-        self._set_schema_heads(required_heads)
+        required_head = _get_required_schema_head()
+        self._set_schema_head(required_head)
 
         with self.app.test_request_context("/health/ready?schema=true", method="GET"):
             res = self.app.full_dispatch_request()
@@ -47,13 +46,13 @@ class APIHealthTestCase(MyTestCase):
             self.assertEqual("ok", res.json["status"])
             self.assertEqual("ok", res.json["checks"]["database"]["status"])
             self.assertEqual("ok", res.json["checks"]["schema"]["status"])
-            self.assertEqual(required_heads, res.json["checks"]["schema"]["required"])
-            self.assertEqual(required_heads, res.json["checks"]["schema"]["current"])
+            self.assertEqual(required_head, res.json["checks"]["schema"]["required"])
+            self.assertEqual(required_head, res.json["checks"]["schema"]["current"])
 
     def test_03_health_reports_schema_mismatch_when_requested(self):
-        self._set_schema_heads(["wrong_revision"])
+        self._set_schema_head("wrong_revision")
 
-        with self.app.test_request_context("/health?schema=true", method="GET"):
+        with self.app.test_request_context("/health/ready?schema=true", method="GET"):
             res = self.app.full_dispatch_request()
             self.assertEqual(503, res.status_code, res.data)
             self.assertEqual("error", res.json["status"])

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -19,6 +19,8 @@
 """
 Test the unauthenticated health endpoints.
 """
+from unittest import mock
+
 from .base import MyTestCase
 
 
@@ -35,3 +37,10 @@ class APIHealthTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(200, res.status_code, res.data)
             self.assertEqual("ok", res.json["status"])
+
+    def test_02_ready_health_reports_unavailable_database(self):
+        with mock.patch("edumfa.api.health.is_db_available", return_value=False):
+            with self.app.test_request_context("/health/ready", method="GET"):
+                res = self.app.full_dispatch_request()
+                self.assertEqual(503, res.status_code, res.data)
+                self.assertEqual({"status": "error"}, res.json)

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,3 +1,24 @@
+#
+# License:  AGPLv3
+# This file is part of eduMFA. eduMFA is a fork of privacyIDEA which was forked from LinOTP.
+# Copyright (c) 2026 eduMFA Project-Team
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Test the unauthenticated health endpoints.
+"""
 from .base import MyTestCase
 
 

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,26 +1,7 @@
-from sqlalchemy import text
-
-from edumfa.api.health import _get_required_schema_head
-from edumfa.models import db
-
 from .base import MyTestCase
 
 
 class APIHealthTestCase(MyTestCase):
-    def _set_schema_head(self, head):
-        db.session.execute(
-            text(
-                "CREATE TABLE IF NOT EXISTS alembic_version ("
-                "version_num VARCHAR(32) NOT NULL, "
-                "CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num))"
-            )
-        )
-        db.session.execute(text("DELETE FROM alembic_version"))
-        db.session.execute(
-            text("INSERT INTO alembic_version (version_num) VALUES (:head)"),
-            {"head": head},
-        )
-        db.session.commit()
 
     def test_00_live_health_is_unauthenticated(self):
         with self.app.test_request_context("/health/live", method="GET"):
@@ -33,28 +14,3 @@ class APIHealthTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(200, res.status_code, res.data)
             self.assertEqual("ok", res.json["status"])
-            self.assertEqual("ok", res.json["checks"]["database"]["status"])
-            self.assertNotIn("schema", res.json["checks"])
-
-    def test_02_ready_health_checks_schema_when_requested(self):
-        required_head = _get_required_schema_head()
-        self._set_schema_head(required_head)
-
-        with self.app.test_request_context("/health/ready?schema=true", method="GET"):
-            res = self.app.full_dispatch_request()
-            self.assertEqual(200, res.status_code, res.data)
-            self.assertEqual("ok", res.json["status"])
-            self.assertEqual("ok", res.json["checks"]["database"]["status"])
-            self.assertEqual("ok", res.json["checks"]["schema"]["status"])
-            self.assertEqual(required_head, res.json["checks"]["schema"]["required"])
-            self.assertEqual(required_head, res.json["checks"]["schema"]["current"])
-
-    def test_03_health_reports_schema_mismatch_when_requested(self):
-        self._set_schema_head("wrong_revision")
-
-        with self.app.test_request_context("/health/ready?schema=true", method="GET"):
-            res = self.app.full_dispatch_request()
-            self.assertEqual(503, res.status_code, res.data)
-            self.assertEqual("error", res.json["status"])
-            self.assertEqual("ok", res.json["checks"]["database"]["status"])
-            self.assertEqual("error", res.json["checks"]["schema"]["status"])


### PR DESCRIPTION
Adds unauthenticated Flask health endpoints for orchestration probes.

`/health/ready` now verify database connectivity, `/health/live` provides a lightweight liveness endpoint. Includes focused tests for live, DB-only readiness.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eduMFA/codesmith/eduMFA/pr/1175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783926546&installation_id=137412999&pr_number=1175&repository=eduMFA%2FeduMFA&return_to=https%3A%2F%2Fgithub.com%2FeduMFA%2FeduMFA%2Fpull%2F1175&signature=8a56217872807b6f2b4af341f6375078ff0c12ceab663b104a6a17db164fca13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->