### PR TITLE
chore(docs): rework docker installation

### DIFF
--- a/doc/installation/docker.rst
+++ b/doc/installation/docker.rst
@@ -5,7 +5,12 @@ Docker Installation
 
 .. index:: docker
 
-eduMFA can be easily deployed using Docker containers. This guide will walk you through the process of installing eduMFA using Docker images from GitHub Registry.
+eduMFA offers a OCI container image which can be used with different container
+engines. The image contains a default logging configuration printing the logs to the
+container log, performs database maintenance on start, and runs the application
+on port 8000.
+
+This page assumes Docker will be used.  
 
 Prerequisites
 .............
@@ -13,15 +18,72 @@ Prerequisites
 Before proceeding, ensure that you have:
 
 1. Docker installed on your system
-2. Access to GitHub Registry
+2. Access to the GitHub container registry
 
+Running eduMFA without compose
+..............................
+
+In general, using a compose file as described
+:ref:`below <install_docker_compose>` is recommended for maintainability and the
+ability to include other services like eduMFA's database. But you can also
+create the container directly:
+
+.. code-block:: bash
+
+   docker run -d -p 8000:8000 --name edumfa ghcr.io/edumfa/edumfa:v1.2.3
+
+This command will:
+
+- Run the container in detached mode (``-d``)
+- Map port 8000 on the host to port 8000 in the container (``-p 8000:8000``)
+- Name the container "edumfa" (``--name edumfa``)
+
+Without a configuration, eduMFA will be unable to start though. See
+:ref:`docker_config` for your options, the examples below use a configuration
+file. You likely also want to mount a volume for the encryption and audit keys
+at ``/etc/edumfa/``. Combined this would look like this:
+
+.. code-block:: bash
+
+   docker run -d -p 8000:8000 -v edumfa-keys:/etc/edumfa -e 'EDUMFA_CONFIGFILE=/run/edumfa/edumfa.cfg' -v /path/to/edumfa.cfg:/run/edumfa/edumfa.cfg:ro --name edumfa ghcr.io/edumfa/edumfa:v1.2.3
+
+This will create a named volume ``edumfa-keys`` that will contain the
+encryption key and the audit key. Make sure to keep them as safe as your
+database backups! Without the encryption key, you won't be able to restore them.
+
+Upgrading eduMFA
+................
+
+To update eduMFA to a newer version, use the new tag and recreate the container:
+
+.. code-block:: bash
+
+   docker pull ghcr.io/edumfa/edumfa:v1.2.4
+   docker stop edumfa
+   docker rm edumfa
+   docker run -d -p 8000:8000 -v edumfa-keys:/etc/edumfa -e 'EDUMFA_CONFIGFILE=/run/edumfa/edumfa.cfg' -v /path/to/edumfa.cfg:/run/edumfa/edumfa.cfg:ro --name edumfa ghcr.io/edumfa/edumfa:v1.2.4
+
+You can see the list of available tags at `the container registry <https://ghcr.io/edumfa/edumfa>`_.
+
+Running your own scripts
+....................
+
+To run your own scripts on startup, put them into the ``/opt/edumfa/user-scripts/`` directory with a ``.sh`` suffix:
+
+.. code-block:: bash
+
+   docker run -d -p 8000:8000 -v /path/to/script.sh:/opt/edumfa/user-scripts/script.sh:ro -v edumfa-keys:/etc/edumfa -e 'EDUMFA_CONFIGFILE=/run/edumfa/edumfa.cfg' -v /path/to/edumfa.cfg:/run/edumfa/edumfa.cfg:ro --name edumfa ghcr.io/edumfa/edumfa:v1.2.4
+
+It will be executed as a bash script before the server process is spawned. It's also possible to execute multiple files by placing multiple scripts with the suffix there [#bashGlobbing]_.
+
+.. _install_docker_compose:
 
 Docker Compose
 ..............
 
-For the most setups you should use Docker Compose. Here's a sample `docker-compose.yml` file also containing a mariadb service. 
-
-The container contains a default logging configuration printing the logs to `stdout`, performs database maintenance on start and runs the application on port 8000.
+To avoid the verbosity of ``docker run`` above, you can use a compose file.
+Here's a sample ``docker-compose.yml`` file also containing a MariaDB service
+using :ref:`environment variable based configuration <docker_config_env>`.
 
 .. code-block:: yaml
 
@@ -44,7 +106,7 @@ The container contains a default logging configuration printing the logs to `std
          retries: 3
 
      edumfa:
-       image: ghcr.io/edumfa/edumfa:latest
+       image: ghcr.io/edumfa/edumfa:v1.2.3
        restart: always
        ports:
          - "8000:8000"
@@ -58,9 +120,6 @@ The container contains a default logging configuration printing the logs to `std
          DB_DATABASE: ${MARIADB_DATABASE}
          SECRET_KEY: ${EDUMFA_SECRET_KEY}
          EDUMFA_PEPPER: ${EDUMFA_PEPPER}
-         EDUMFA_ADMIN_USER: ${EDUMFA_ADMIN_USER}
-         EDUMFA_ADMIN_PASS: ${EDUMFA_ADMIN_PASS}
-         EDUMFA_UI_DEACTIVATED: ${EDUMFA_UI_DEACTIVATED}
        depends_on:
          mariadb:
            condition: service_healthy
@@ -70,12 +129,41 @@ The container contains a default logging configuration printing the logs to `std
      mariadb-data:
 
 
-The `.env` file should contain the following variables:
+The above environment variables would have to be declared in the ``.env`` file.
+The database can of course also be located elsewhere, as long as it's reachable.
+Adding a reverse proxy is left as an exercise to the reader.
 
-- MARIADB_DATABASE: the MariaDB database
-- MARIADB_PASSWORD: the MariaDB password
-- MARIADB_ROOT_PASSWORD: the MariaDB root password (not used by eduMFA, required)
-- MARIADB_USER: the MariaDB user
+
+To start eduMFA using Docker Compose, in the same directory run:
+
+.. code-block:: bash
+
+   docker compose up -d
+
+For more information on using eduMFA, please refer to :ref:`first_steps`.
+
+.. _docker_config:
+
+Configuration
+.............
+
+There are two ways of configuring eduMFA in the image: via environment variables
+or via a classic configuration file. Environment variables simplify
+configuration but might not be sufficient for advanced configurations.
+
+.. _docker_config_env:
+
+via environment variables
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Below are the variables which are available. Those which are not marked as
+optional are required for eduMFA to work.
+
+- DB_DATABASE: the database to use on the database system
+- DB_DRIVER: The driver for the database system, which is the first part of the :ref:`database_connect` until the colon.
+- DB_HOSTNAME: the hostname of the database system
+- DB_PASSWORD: the password for DB_USER
+- DB_USER: the user on the database system
 - EDUMFA_PEPPER: the pepper to use for password hashing, should be at least 24 random characters long
 - EDUMFA_SECRET_KEY: the secret key which signs API tokens, should be at least 24 random characters long
 - EDUMFA_ADMIN_PASS: the password for the local eduMFA admin (optional, default: will be generated)
@@ -90,86 +178,24 @@ The `.env` file should contain the following variables:
 - EDUMFA_LOGO: filename of custom logo (optional)
 - EDUMFA_PAGE_TITLE: custom page title (optional)
 
-You can also add a "_FILE" suffix to each variable name and pass a path to read the value from a file instead. For example instead of passing `SECRET_KEY`:
+You can also add a "_FILE" suffix to each variable name and pass a path to read
+the value from a file instead. This is helpful if used with a secret manager
+such as Docker Secrets, and is also considered best practice for sensitive data.
+
+For example instead of passing ``SECRET_KEY``:
 
 .. code-block:: bash
 
    SECRET_KEY_FILE: /etc/edumfa/secret_key.txt
 
-Alternatively, you can mount your own `edumfa.cfg` instead of configuring eduMFA via environment variables.
+via configuration file
+~~~~~~~~~~~~~~~~~~~~~~
 
-To start eduMFA using Docker Compose, run:
-
-.. code-block:: bash
-
-   docker compose up -d
-
-For more information on using eduMFA, please refer to :ref:`first_steps`.
-
-Pulling the eduMFA Docker Image
-...............................
-
-To pull the eduMFA Docker image without `docker compose` from GitHub Registry, use the following command:
-
-.. code-block:: bash
-
-   docker pull ghcr.io/edumfa/edumfa:latest
-
-You can replace `latest` with a specific version tag if needed e.g. `2.2.0`
-
-Running eduMFA Container
-........................
-
-To run the eduMFA container, use the following command:
-
-.. code-block:: bash
-
-   docker run -d -p 8000:8000 --name edumfa ghcr.io/edumfa/edumfa:latest
-
-This command will:
-
-- Run the container in detached mode (`-d`)
-- Map port 8000 on the host to port 8000 in the container (`-p 8000:8000`)
-- Name the container "edumfa" (`--name edumfa`)
-
-Running your own scripts
-....................
-
-To run your own scripts on startup, put it into the `/opt/edumfa/user-scripts/` directory with a `.sh` suffix:
-
-.. code-block:: bash
-
-   docker run -d -p 8000:8000 -v /path/to/script.sh:/opt/edumfa/user-scripts/script.sh --name edumfa ghcr.io/edumfa/edumfa:latest
-
-It will be executed as a bash script. It's also possible to execute multiple files by placing multiple scripts with the suffix there [#bashGlobbing]_.
-
-Persistent Data 
-...............
-
-To persist data between container restarts, you can mount a volume for the database:
-
-.. code-block:: bash
-
-   docker run -d -p 8000:8000 -v /path/to/edumfa.cfg:/etc/edumfa/edumfa.cfg -v edumfa-config:/etc/edumfa --name edumfa ghcr.io/edumfa/edumfa:latest
-
-This will create a named volume `edumfa-config` that will persist your eduMFA configuration. This volume will contain the encryption key and the audit key.
-
-Depending on your own configuration and your individual setup you may need to adjust the paths.
-
-Updating eduMFA manually
-...............
-
-To update eduMFA to a newer version, pull the latest image and recreate the container:
-
-.. code-block:: bash
-
-   docker pull ghcr.io/edumfa/edumfa:latest
-   docker stop edumfa
-   docker rm edumfa
-   docker run -d -p 8000:8000 -v /path/to/edumfa.cfg:/etc/edumfa/edumfa.cfg -v edumfa-config:/etc/edumfa --name edumfa ghcr.io/edumfa/edumfa:latest
-
+Alternatively, you can mount your own ``edumfa.cfg`` instead of configuring
+eduMFA via environment variables. To do so, mount it as a file and set the
+environment variable ``EDUMFA_CONFIGFILE`` to its path.
 
 .. rubric:: Footnotes
 
-.. [#bashGlobbing] The execution order depends on the way Bash expands `*.sh`. Read more in the `POSIX specification`_.
+.. [#bashGlobbing] The execution order depends on the way Bash expands ``*.sh``. Read more in the `POSIX specification`_.
 .. _POSIX specification: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_13_03

--- a/doc/installation/docker.rst
+++ b/doc/installation/docker.rst
@@ -30,7 +30,7 @@ create the container directly:
 
 .. code-block:: bash
 
-   docker run -d -p 8000:8000 --name edumfa ghcr.io/edumfa/edumfa:v1.2.3
+   docker run -d -p 8000:8000 --name edumfa ghcr.io/edumfa/edumfa:1.2.3
 
 This command will:
 
@@ -45,7 +45,7 @@ at ``/etc/edumfa/``. Combined this would look like this:
 
 .. code-block:: bash
 
-   docker run -d -p 8000:8000 -v edumfa-keys:/etc/edumfa -e 'EDUMFA_CONFIGFILE=/run/edumfa/edumfa.cfg' -v /path/to/edumfa.cfg:/run/edumfa/edumfa.cfg:ro --name edumfa ghcr.io/edumfa/edumfa:v1.2.3
+   docker run -d -p 8000:8000 -v edumfa-keys:/etc/edumfa -e 'EDUMFA_CONFIGFILE=/run/edumfa/edumfa.cfg' -v /path/to/edumfa.cfg:/run/edumfa/edumfa.cfg:ro --name edumfa ghcr.io/edumfa/edumfa:1.2.3
 
 This will create a named volume ``edumfa-keys`` that will contain the
 encryption key and the audit key. Make sure to keep them as safe as your
@@ -106,7 +106,7 @@ using :ref:`environment variable based configuration <docker_config_env>`.
          retries: 3
 
      edumfa:
-       image: ghcr.io/edumfa/edumfa:v1.2.3
+       image: ghcr.io/edumfa/edumfa:1.2.3
        restart: always
        ports:
          - "8000:8000"
@@ -164,8 +164,8 @@ optional are required for eduMFA to work.
 - DB_HOSTNAME: the hostname of the database system
 - DB_PASSWORD: the password for DB_USER
 - DB_USER: the user on the database system
+- SECRET_KEY: the secret key which signs API tokens, should be at least 24 random characters long
 - EDUMFA_PEPPER: the pepper to use for password hashing, should be at least 24 random characters long
-- EDUMFA_SECRET_KEY: the secret key which signs API tokens, should be at least 24 random characters long
 - EDUMFA_ADMIN_PASS: the password for the local eduMFA admin (optional, default: will be generated)
 - EDUMFA_ADMIN_USER: the username for the local eduMFA admin (optional, default: ``admin``)
 - EDUMFA_AUDIT_KEY_PRIVATE: an alternative path to the audit key (optional, default: ``/etc/edumfa/private.pem``)


### PR DESCRIPTION
The current docker installation page is quite messy. This PR tries to make a little more sense by moving things around and clearly separating the example compose file and the available configuration options.  
Also sets a fake version string instead of "latest" to avoid users being surprised by sudden changes.