### PR TITLE
feat: add WebAuthn offline authentication support

### DIFF
--- a/edumfa/api/lib/postpolicy.py
+++ b/edumfa/api/lib/postpolicy.py
@@ -551,10 +551,12 @@ def save_pin_change(request, response, serial=None):
 def offline_info(request, response):
     """
     This decorator is used with the function /validate/check.
-    It is not triggered by an ordinary policy but by a MachineToken definition.
-    If for the given Token an offline application is defined,
-    the response is enhanced with the offline information - the hashes of the
-    OTP.
+    It is triggered by a MachineToken definition (the token must be attached
+    to the offline application). For WebAuthn tokens the attachment does not
+    need to specify a particular machine hostname — any machine that
+    successfully authenticates online receives the offline data (public key,
+    credential ID, relying party ID, and a per-machine refill token keyed by
+    the computer name in the User-Agent).
 
     """
     content = response.json
@@ -568,6 +570,7 @@ def offline_info(request, response):
                     serial=serial,
                     application="offline",
                     challenge=request.all_data.get("pass"),
+                    user_agent=request.user_agent.string,
                 )
                 if auth_items:
                     content["auth_items"] = auth_items

--- a/edumfa/api/machine.py
+++ b/edumfa/api/machine.py
@@ -479,6 +479,7 @@ def get_auth_items_api(application=None):
         application=application,
         challenge=challenge,
         filter_param=filter_param,
+        user_agent=request.user_agent.string,
     )
     g.audit_object.log(
         {

--- a/edumfa/api/validate.py
+++ b/edumfa/api/validate.py
@@ -117,7 +117,7 @@ from edumfa.lib.token import (
     get_tokens,
 )
 from edumfa.lib.user import get_user_from_param, log_used_user
-from edumfa.lib.utils import get_client_ip, is_true
+from edumfa.lib.utils import get_client_ip, get_computer_name_from_user_agent, is_true
 
 from ..lib.decorators import check_user_or_serial_in_request
 from ..lib.framework import get_app_config_value
@@ -185,7 +185,7 @@ def offlinerefill():
     :return:
     """
     serial = getParam(request.all_data, "serial", required)
-    refilltoken = getParam(request.all_data, "refilltoken", required)
+    refilltoken_request = getParam(request.all_data, "refilltoken", required)
     password = getParam(request.all_data, "pass", required)
     tokenobj_list = get_tokens(serial=serial)
     if len(tokenobj_list) != 1:
@@ -198,20 +198,51 @@ def offlinerefill():
             # We need the options to pass the count and the rounds for the next offline OTP values,
             # which could have changed in the meantime.
             options = tokenattachments[0].get("options")
-            # check refill token:
-            if tokenobj.get_tokeninfo("refilltoken") == refilltoken:
-                # refill
-                otps = MachineApplication.get_refill(tokenobj, password, options)
-                refilltoken = MachineApplication.generate_new_refilltoken(tokenobj)
-                response = send_result(True)
-                content = response.json
-                content["auth_items"] = {
-                    "offline": [
-                        {"refilltoken": refilltoken, "response": otps, "serial": serial}
-                    ]
-                }
-                response.set_data(json.dumps(content))
-                return response
+            # Check the refill token depending on the token type. WebAuthn
+            # tokens track a refill token per machine, identified by the
+            # computer name in the user agent.
+            if tokenobj.type.lower() == "webauthn":
+                computer_name = get_computer_name_from_user_agent(
+                    request.user_agent.string
+                )
+                if computer_name is None:
+                    raise ParameterError("The computer name is missing.")
+                refilltoken_stored = tokenobj.get_tokeninfo(
+                    "refilltoken_" + computer_name
+                )
+                if refilltoken_stored and refilltoken_stored == refilltoken_request:
+                    refilltoken_new = MachineApplication.generate_new_refilltoken(
+                        tokenobj, request.user_agent.string
+                    )
+                    response = send_result(True)
+                    content = response.json
+                    # A WebAuthn token authenticates offline with the cached
+                    # public key, so there are no new OTP values to refill.
+                    content["auth_items"] = {
+                        "offline": [{"refilltoken": refilltoken_new, "serial": serial}]
+                    }
+                    response.set_data(json.dumps(content))
+                    return response
+            else:
+                refilltoken_stored = tokenobj.get_tokeninfo("refilltoken")
+                if refilltoken_stored and refilltoken_stored == refilltoken_request:
+                    otps = MachineApplication.get_refill(tokenobj, password, options)
+                    refilltoken_new = MachineApplication.generate_new_refilltoken(
+                        tokenobj
+                    )
+                    response = send_result(True)
+                    content = response.json
+                    content["auth_items"] = {
+                        "offline": [
+                            {
+                                "refilltoken": refilltoken_new,
+                                "response": otps,
+                                "serial": serial,
+                            }
+                        ]
+                    }
+                    response.set_data(json.dumps(content))
+                    return response
         raise ParameterError(
             "Token is not an offline token or refill token is incorrect"
         )

--- a/edumfa/lib/applications/base.py
+++ b/edumfa/lib/applications/base.py
@@ -94,7 +94,8 @@ class MachineApplication:
 
     @staticmethod
     def get_authentication_item(
-        token_type, serial, challenge=None, options=None, filter_param=None
+        token_type, serial, challenge=None, options=None, filter_param=None,
+        user_agent=None
     ):
         """
         returns a dictionary of authentication items
@@ -118,7 +119,8 @@ class MachineApplication:
 
 @log_with(log)
 def get_auth_item(
-    application, token_type, serial, challenge=None, options=None, filter_param=None
+    application, token_type, serial, challenge=None, options=None, filter_param=None,
+    user_agent=None
 ):
     options = options or {}
     # application_module from application
@@ -131,6 +133,7 @@ def get_auth_item(
         challenge=challenge,
         options=options,
         filter_param=filter_param,
+        user_agent=user_agent,
     )
     return auth_item
 

--- a/edumfa/lib/applications/luks.py
+++ b/edumfa/lib/applications/luks.py
@@ -43,7 +43,8 @@ class MachineApplication(MachineApplicationBase):
 
     @staticmethod
     def get_authentication_item(
-        token_type, serial, challenge=None, options=None, filter_param=None
+        token_type, serial, challenge=None, options=None, filter_param=None,
+        user_agent=None
     ):
         """
         :param token_type: the type of the token. At the moment

--- a/edumfa/lib/applications/offline.py
+++ b/edumfa/lib/applications/offline.py
@@ -27,6 +27,7 @@ from edumfa.lib.crypto import geturandom
 from edumfa.lib.error import ParameterError, ValidateError
 from edumfa.lib.policy import TYPE
 from edumfa.lib.token import get_tokens
+from edumfa.lib.utils import get_computer_name_from_user_agent
 
 log = logging.getLogger(__name__)
 ROUNDS = 6549
@@ -54,14 +55,35 @@ class MachineApplication(MachineApplicationBase):
     application_name = "offline"
 
     @staticmethod
-    def generate_new_refilltoken(token_obj):
+    def generate_new_refilltoken(token_obj, user_agent=None):
         """
         Generate new refill token and store it in the tokeninfo of the token.
+
+        For WebAuthn tokens the refill token is stored per machine, because the
+        same token can be used for offline authentication on multiple machines,
+        which need to be managed separately. The machine is identified by the
+        computer name contained in the user agent.
+
         :param token_obj: token in question
+        :param user_agent: the user agent of the request, used to derive the
+            machine name for WebAuthn tokens
         :return: a string
         """
+
+        log.debug(f"Generating refilltoken for token {token_obj.get_serial()!r} with user agent {user_agent}")
+
+        if token_obj.type.lower() == "webauthn":
+            computer_name = get_computer_name_from_user_agent(user_agent)
+            if computer_name is None:
+                raise ParameterError(
+                    "Unable to generate refilltoken for a WebAuthn token "
+                    "without a computer name."
+                )
+            key = "refilltoken_" + computer_name
+        else:
+            key = "refilltoken"
         new_refilltoken = geturandom(REFILLTOKEN_LENGTH, hex=True)
-        token_obj.add_tokeninfo("refilltoken", new_refilltoken)
+        token_obj.add_tokeninfo(key, new_refilltoken)
         return new_refilltoken
 
     @staticmethod
@@ -133,43 +155,59 @@ class MachineApplication(MachineApplicationBase):
 
     @staticmethod
     def get_authentication_item(
-        token_type, serial, challenge=None, options=None, filter_param=None
+        token_type, serial, challenge=None, options=None, filter_param=None,
+        user_agent=None
     ):
         """
-        :param token_type: the type of the token. At the moment
-                           we only support "HOTP" token. Supporting time
-                           based tokens is difficult, since we would have to
-                           return a looooong list of OTP values.
-                           Supporting "yubikey" token (AES) would be
-                           possible, too.
+        :param token_type: the type of the token. At the moment we support
+                           "HOTP" tokens and "WebAuthn" tokens. Supporting
+                           time based tokens is difficult, since we would have
+                           to return a looooong list of OTP values.
         :param serial:     the serial number of the token.
         :param challenge:  This can contain the password (otp pin + otp
         value) so that we can put the OTP PIN into the hashed response.
         :type challenge: basestring
-        :return auth_item: A list of hashed OTP values
+        :param options: options
+        :param filter_param: parameters
+        :param user_agent: The user agent of the request, used to derive the
+            machine name for WebAuthn tokens
+        :return auth_item: A list of hashed OTP values or pubKey, rpId and
+            credentialId for a WebAuthn token
         """
         ret = {}
         options = options or {}
         password = challenge
-        if token_type.lower() == "hotp":
+        if token_type.lower() in ["hotp", "webauthn"]:
             tokens = get_tokens(serial=serial)
             if len(tokens) == 1:
                 token_obj = tokens[0]
-                if password:
-                    _r, otppin, _ = token_obj.split_pin_pass(password)
-                    if not _r:
-                        raise ParameterError("Could not split password")
+
+                if token_type.lower() == "webauthn":
+                    # Return the pubKey, rpId and the credentialId (contained
+                    # in the otpkey) to allow the machine to verify the
+                    # WebAuthn assertions signed with the token offline.
+                    ret["response"] = {
+                        "pubKey": token_obj.get_tokeninfo("pubKey"),
+                        "credentialId": token_obj.decrypt_otpkey(),
+                        "rpId": token_obj.get_tokeninfo("relying_party_id"),
+                    }
                 else:
-                    otppin = ""
-                otps = MachineApplication.get_offline_otps(
-                    token_obj,
-                    otppin,
-                    int(options.get("count", 100)),
-                    int(options.get("rounds", ROUNDS)),
+                    if password:
+                        _r, otppin, _ = token_obj.split_pin_pass(password)
+                        if not _r:
+                            raise ParameterError("Could not split password")
+                    else:
+                        otppin = ""
+                    ret["response"] = MachineApplication.get_offline_otps(
+                        token_obj,
+                        otppin,
+                        int(options.get("count", 100)),
+                        int(options.get("rounds", ROUNDS)),
+                    )
+
+                ret["refilltoken"] = MachineApplication.generate_new_refilltoken(
+                    token_obj, user_agent
                 )
-                refilltoken = MachineApplication.generate_new_refilltoken(token_obj)
-                ret["response"] = otps
-                ret["refilltoken"] = refilltoken
                 user_object = token_obj.user
                 if user_object:
                     uInfo = user_object.info

--- a/edumfa/lib/applications/ssh.py
+++ b/edumfa/lib/applications/ssh.py
@@ -54,7 +54,8 @@ class MachineApplication(MachineApplicationBase):
 
     @staticmethod
     def get_authentication_item(
-        token_type, serial, challenge=None, options=None, filter_param=None
+        token_type, serial, challenge=None, options=None, filter_param=None,
+        user_agent=None
     ):
         """
         :param token_type: the type of the token. At the moment

--- a/edumfa/lib/machine.py
+++ b/edumfa/lib/machine.py
@@ -5,6 +5,8 @@
 # Previous authors by privacyIDEA project:
 #
 # 2015 Cornelius Kölbel <cornelius@privacyidea.org>
+# 2025 Daniel Valencia <daniel.valencia@pal-robotics.com>
+#      Add WebAuthn offline authentication support (ported from privacyIDEA PR #3874)
 #
 # This code is free software; you can redistribute it and/or
 # modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -515,6 +517,7 @@ def get_auth_items(
     serial=None,
     challenge=None,
     filter_param=None,
+    user_agent=None,
 ):
     """
     Return the authentication items for a given hostname and the application.
@@ -562,6 +565,7 @@ def get_auth_items(
             challenge,
             options=mtoken.get("options"),
             filter_param=filter_param,
+            user_agent=user_agent,
         )
         if auth_item:
             if mtoken.get("application") not in auth_items:

--- a/edumfa/lib/utils/__init__.py
+++ b/edumfa/lib/utils/__init__.py
@@ -5,6 +5,8 @@
 # Previous authors by privacyIDEA project:
 #
 # 2015 - 2017 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+# 2025 Daniel Valencia <daniel.valencia@pal-robotics.com>
+#      Add WebAuthn offline authentication support (ported from privacyIDEA PR #3874)
 #
 # This code is free software; you can redistribute it and/or
 # modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -1584,3 +1586,47 @@ def convert_imagefile_to_dataimage(imagepath):
     except FileNotFoundError:
         log.warning(f"The file {imagepath} could not be found.")
         return ""
+
+
+def get_computer_name_from_user_agent(user_agent):
+    """
+    Searches for entries in the user agent that could identify the machine.
+    Example: ComputerName/Laptop-3324231
+
+    The following keys are searched for in the user agent by default:
+    ["ComputerName", "Hostname", "MachineName", "Windows", "Linux", "Mac"]
+    The list can be extended with custom keys in edumfa.cfg with the entry
+    OFFLINE_MACHINE_KEYS = ["CustomKey1", ...]
+
+    This is required for offline WebAuthn tokens, since the same token (e.g. a
+    security key) can be enrolled for offline use on multiple machines and each
+    machine needs its own refill token.
+
+    :param user_agent: The user agent string sent by the client
+    :type user_agent: str or None
+    :return: The computer name or None if no matching key was found
+    :rtype: str or None
+    """
+    from edumfa.lib.framework import get_app_config_value
+
+    if not user_agent:
+        log.warning("No user agent provided to extract computer name from.")
+        return None
+    # Do not convert to set, the order of the keys should be preserved and
+    # iteration should be deterministic
+    keys = ["ComputerName", "Hostname", "MachineName", "Windows", "Linux", "Mac"]
+    try:
+        config_keys = get_app_config_value("OFFLINE_MACHINE_KEYS", []) or []
+    except RuntimeError:
+        # Called outside an application context: only use the default keys
+        config_keys = []
+    keys.extend([key for key in config_keys if key not in keys])
+    log.debug(f"Keys to search for machine name in user agent: {keys}")
+    for key in keys:
+        if key in user_agent:
+            try:
+                return user_agent.split(key + "/")[1].split(" ")[0]
+            except Exception:
+                # Likely to happen, because parts like "Mac" are common
+                pass
+    return None

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -7326,3 +7326,120 @@ class ValidateShortPasswordTestCase(MyApiTestCase):
             detail = res.json.get("detail")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
+
+
+class WebAuthnOfflineRefillTestCase(MyApiTestCase):
+    """
+    Test the /validate/offlinerefill endpoint for WebAuthn tokens, which use a
+    per-machine refill token identified by the computer name in the User-Agent.
+    """
+
+    serial = "WANREFILL1"
+    ua_a = "eduMFACredentialProvider/3.0 ComputerName/DESK-A Windows/10"
+    ua_b = "eduMFACredentialProvider/3.0 ComputerName/DESK-B Windows/11"
+    ua_none = "Mozilla/5.0"
+
+    def test_00_setup(self):
+        from edumfa.lib.applications.offline import MachineApplication
+        from edumfa.lib.machine import attach_token
+        from edumfa.lib.machineresolver import save_resolver
+
+        self.setUp_user_realms()
+        save_resolver(
+            {
+                "name": "wanres",
+                "type": "hosts",
+                "filename": HOSTSFILE,
+                "type.filename": "string",
+                "pw": "secret",
+                "type.pw": "password",
+            }
+        )
+        db_token = Token(self.serial, tokentype="webauthn")
+        db_token.update_otpkey("1234567890abcdef")
+        db_token.save()
+        tok = get_tokens(serial=self.serial)[0]
+        tok.add_user(User("cornelius", self.realm1))
+        tok.add_tokeninfo("pubKey", "this-is-a-public-key")
+        tok.add_tokeninfo("relying_party_id", "example.com")
+        attach_token(self.serial, "offline", hostname="pippin", resolver_name="wanres")
+
+        # Simulate the online login that seeds the per-machine offline data
+        # (this is what offline_info does after a successful authentication)
+        ai_a = MachineApplication.get_authentication_item(
+            "webauthn", self.serial, user_agent=self.ua_a
+        )
+        self.assertEqual(
+            ai_a.get("refilltoken"), tok.get_tokeninfo("refilltoken_DESK-A")
+        )
+
+    def test_01_offlinerefill_webauthn(self):
+        # A valid refill from machine DESK-A returns a NEW refill token and no
+        # OTP values (WebAuthn authenticates offline with the cached pubKey).
+        tok = get_tokens(serial=self.serial)[0]
+        current_rt = tok.get_tokeninfo("refilltoken_DESK-A")
+        with self.app.test_request_context(
+            "/validate/offlinerefill",
+            method="POST",
+            data={
+                "serial": self.serial,
+                "pass": "",
+                "refilltoken": current_rt,
+            },
+            headers={"User-Agent": self.ua_a},
+        ):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200, res)
+            offline = res.json.get("auth_items").get("offline")[0]
+            new_rt = offline.get("refilltoken")
+            self.assertEqual(offline.get("serial"), self.serial)
+            self.assertNotIn("response", offline)
+            self.assertNotEqual(new_rt, current_rt)
+            tok = get_tokens(serial=self.serial)[0]
+            self.assertEqual(new_rt, tok.get_tokeninfo("refilltoken_DESK-A"))
+
+    def test_02_wrong_refilltoken_fails(self):
+        with self.app.test_request_context(
+            "/validate/offlinerefill",
+            method="POST",
+            data={
+                "serial": self.serial,
+                "pass": "",
+                "refilltoken": "f" * 80,
+            },
+            headers={"User-Agent": self.ua_a},
+        ):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 400, res)
+
+    def test_03_unknown_machine_fails(self):
+        # DESK-B never did an online login, so it has no refill token
+        with self.app.test_request_context(
+            "/validate/offlinerefill",
+            method="POST",
+            data={
+                "serial": self.serial,
+                "pass": "",
+                "refilltoken": "f" * 80,
+            },
+            headers={"User-Agent": self.ua_b},
+        ):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 400, res)
+
+    def test_04_missing_computer_name_fails(self):
+        with self.app.test_request_context(
+            "/validate/offlinerefill",
+            method="POST",
+            data={
+                "serial": self.serial,
+                "pass": "",
+                "refilltoken": "f" * 80,
+            },
+            headers={"User-Agent": self.ua_none},
+        ):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 400, res)
+            msg = res.json.get("result").get("error").get("message")
+            self.assertIn("computer name is missing", msg)
+

--- a/tests/test_lib_applications.py
+++ b/tests/test_lib_applications.py
@@ -232,3 +232,84 @@ class BaseApplicationTestCase(MyTestCase):
         self.assertIn("user", apps["ssh"]["options"])
         self.assertIn("slot", apps["luks"]["options"])
         self.assertIn("partition", apps["luks"]["options"])
+
+class OfflineWebAuthnApplicationTestCase(MyTestCase):
+    """
+    Test offline authentication item generation and per-machine refill tokens
+    for WebAuthn tokens.
+    """
+
+    serial = "WAN0001"
+    ua_machine_a = "eduMFACredentialProvider/3.0 ComputerName/DESK-A Windows/10"
+    ua_machine_b = "eduMFACredentialProvider/3.0 ComputerName/DESK-B Windows/11"
+    ua_no_machine = "Mozilla/5.0"
+
+    def _create_webauthn_token(self, serial):
+        from edumfa.models import Token
+
+        db_token = Token(serial, tokentype="webauthn")
+        db_token.update_otpkey("1234567890abcdef")
+        db_token.save()
+        tok = get_tokens(serial=serial)[0]
+        tok.add_tokeninfo("pubKey", "this-is-a-public-key")
+        tok.add_tokeninfo("relying_party_id", "example.com")
+        return tok
+
+    def test_01_webauthn_offline_auth_item(self):
+        serial = "WAN0001"
+        tok = self._create_webauthn_token(serial)
+
+        auth_item = OfflineApplication.get_authentication_item(
+            "webauthn", serial, user_agent=self.ua_machine_a
+        )
+        # WebAuthn offline returns the data needed to verify assertions locally
+        response = auth_item.get("response")
+        self.assertEqual(response.get("pubKey"), "this-is-a-public-key")
+        self.assertEqual(response.get("rpId"), "example.com")
+        self.assertEqual(response.get("credentialId"), tok.decrypt_otpkey())
+        # There are no OTP values for a WebAuthn token
+        self.assertNotIn("hotp", response)
+
+        refilltoken_a = auth_item.get("refilltoken")
+        self.assertEqual(len(refilltoken_a), REFILLTOKEN_LENGTH * 2)
+        # The refill token is stored per machine
+        self.assertEqual(refilltoken_a, tok.get_tokeninfo("refilltoken_DESK-A"))
+        # The generic (HOTP-style) refilltoken key must NOT be set
+        self.assertEqual(tok.get_tokeninfo("refilltoken"), None)
+
+    def test_02_separate_refilltoken_per_machine(self):
+        serial = "WAN0002"
+        tok = self._create_webauthn_token(serial)
+
+        ai_a = OfflineApplication.get_authentication_item(
+            "webauthn", serial, user_agent=self.ua_machine_a
+        )
+        ai_b = OfflineApplication.get_authentication_item(
+            "webauthn", serial, user_agent=self.ua_machine_b
+        )
+        rt_a = ai_a.get("refilltoken")
+        rt_b = ai_b.get("refilltoken")
+
+        # Each machine has its own, distinct refill token
+        self.assertNotEqual(rt_a, rt_b)
+        self.assertEqual(rt_a, tok.get_tokeninfo("refilltoken_DESK-A"))
+        self.assertEqual(rt_b, tok.get_tokeninfo("refilltoken_DESK-B"))
+
+    def test_03_missing_computer_name_raises(self):
+        serial = "WAN0003"
+        self._create_webauthn_token(serial)
+        # Without a derivable computer name we cannot key the refill token
+        self.assertRaises(
+            ParameterError,
+            OfflineApplication.get_authentication_item,
+            "webauthn",
+            serial,
+            user_agent=self.ua_no_machine,
+        )
+        self.assertRaises(
+            ParameterError,
+            OfflineApplication.get_authentication_item,
+            "webauthn",
+            serial,
+            user_agent=None,
+        )

--- a/tests/test_lib_utils.py
+++ b/tests/test_lib_utils.py
@@ -1169,3 +1169,33 @@ class UtilsTestCase(MyTestCase):
         file = "./tests/testdata/logging.cfg"
         dataimage = convert_imagefile_to_dataimage(file)
         self.assertEqual("", dataimage)
+
+
+class ComputerNameFromUserAgentTestCase(MyTestCase):
+    """
+    Tests for get_computer_name_from_user_agent, used to key per-machine
+    offline refill tokens for WebAuthn tokens.
+    """
+
+    def test_01_extract_computer_name(self):
+        from edumfa.lib.utils import get_computer_name_from_user_agent
+
+        ua = "eduMFACredentialProvider/3.0 ComputerName/DESK-01 Windows/10"
+        self.assertEqual(get_computer_name_from_user_agent(ua), "DESK-01")
+
+        # Other supported keys
+        self.assertEqual(
+            get_computer_name_from_user_agent("client Hostname/host-7 foo"),
+            "host-7",
+        )
+        self.assertEqual(
+            get_computer_name_from_user_agent("client MachineName/MX1"),
+            "MX1",
+        )
+
+    def test_02_no_computer_name(self):
+        from edumfa.lib.utils import get_computer_name_from_user_agent
+
+        self.assertIsNone(get_computer_name_from_user_agent("Mozilla/5.0"))
+        self.assertIsNone(get_computer_name_from_user_agent(""))
+        self.assertIsNone(get_computer_name_from_user_agent(None))


### PR DESCRIPTION
Port of privacyIDEA PR #3874. Enables offline login with FIDO2 security keys via the privacyIDEA Credential Provider.

Closes #1194