### PR TITLE
fix(ci): correct path filter for docker action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,13 +11,15 @@ on:
     paths:
       - '.github/workflows/docker.yml'
       - 'deploy/docker/**'
-      - 'edumfa/**/*.py'
+      - 'edumfa/**'
+      - 'migrations/**'
       - 'tools/**'
-      - '.docerignore'
+      - '.dockerignore'
       - 'Dockerfile'
       - 'edumfa-manage'
       - 'pyproject.toml'
       - 'setup.py'
+      - 'uv.lock'
   pull_request:
     types: [ opened, reopened, synchronize ]
 


### PR DESCRIPTION
Correct path filters in the CI configuration to ensure proper handling of Docker image builds. 

This includes adjustments to the paths for Python files, migrations, and the Docker ignore file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eduMFA/codesmith/eduMFA/pr/1198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785739898&installation_id=137412999&pr_number=1198&repository=eduMFA%2FeduMFA&return_to=https%3A%2F%2Fgithub.com%2FeduMFA%2FeduMFA%2Fpull%2F1198&signature=9889bbfcf6f3fe59194dbe474aa9e52a16bed3e78535811fb6143a86c24d5f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->