### PR TITLE
chore: remove superfluous env vars for docker-example

### DIFF
--- a/deploy/docker-example/docker-compose.yml
+++ b/deploy/docker-example/docker-compose.yml
@@ -4,10 +4,12 @@ services:
     restart: always
     volumes:
       - mariadb-data:/var/lib/mysql:rw
+    secrets:
+      - db_password
     environment:
       MARIADB_DATABASE: ${MARIADB_DATABASE}
       MARIADB_USER: ${MARIADB_USER}
-      MARIADB_PASSWORD: ${MARIADB_PASSWORD}
+      MARIADB_PASSWORD_FILE: /run/secrets/db_password
       MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
@@ -31,7 +33,7 @@ services:
       - db_password
     environment:
       DB_DATABASE: ${MARIADB_DATABASE}
-      DB_DRIVER: ${DB_DRIVER}
+      DB_DRIVER: mysql+pymysql
       DB_HOSTNAME: mariadb
       DB_PASSWORD_FILE: /run/secrets/db_password
       DB_USER: ${MARIADB_USER}

--- a/deploy/docker-example/env-example
+++ b/deploy/docker-example/env-example
@@ -1,15 +1,11 @@
 ## eduMFA docker config
 MARIADB_USER="edumfa"
-MARIADB_PASSWORD="pass"
 MARIADB_DATABASE="edumfa"
 MARIADB_ROOT_PASSWORD="rootpass"
-
-DB_DRIVER="mysql+pymysql"
 
 EDUMFA_SECRET_KEY="Secret-Use-Your-Own-Values-Please"
 EDUMFA_PEPPER="Never know..."
 
 EDUMFA_ADMIN_USER="admin"
-EDUMFA_ADMIN_PASS="Passwort123"
 SUPERUSER_REALM="super,administrators"
 EDUMFA_UI_DEACTIVATED="False"


### PR DESCRIPTION
Remove secrets from `env-example` that are now read as docker secrets. Defining the driver as an env var does not make sense when the DB is dictated by `docker-compose.yaml`. Move it there.