### PR TITLE
fix: use for_update in tokeninfo update

### DIFF
--- a/edumfa/models.py
+++ b/edumfa/models.py
@@ -720,7 +720,16 @@ class TokenInfo(MethodsMixin, db.Model):
         self.Description = Description
 
     def save(self, persistent=True):
-        ti_func = TokenInfo.query.filter_by(token_id=self.token_id, Key=self.Key).first
+        # Use a locking read (SELECT ... FOR UPDATE) so concurrent saves of the
+        # same (token_id, Key) row serialize instead of racing. This avoids the
+        # MariaDB error 1020 (ER_CHECKREAD) that concurrent token validations
+        # trigger when they update the same tokeninfo row. FOR UPDATE is a no-op
+        # on SQLite (silently ignored by its dialect).
+        ti_func = (
+            TokenInfo.query.filter_by(token_id=self.token_id, Key=self.Key)
+            .with_for_update()
+            .first
+        )
         ti = ti_func()
         if ti is None:
             # create a new one
@@ -732,14 +741,11 @@ class TokenInfo(MethodsMixin, db.Model):
             else:
                 ret = self.id
         else:
-            # update
-            TokenInfo.query.filter_by(token_id=self.token_id, Key=self.Key).update(
-                {
-                    "Value": self.Value,
-                    "Description": self.Description,
-                    "Type": self.Type,
-                }
-            )
+            # Update the row we just locked with FOR UPDATE in this same
+            # transaction, instead of issuing a second, separate query for it.
+            ti.Value = self.Value
+            ti.Description = self.Description
+            ti.Type = self.Type
             ret = ti.id
         if persistent:
             db.session.commit()


### PR DESCRIPTION
This pull request changes the `save` method in `edumfa/models.py` to improve database concurrency handling and reduce the risk of race conditions during token validation. The main improvements are the use of row-level locking to serialize concurrent updates and updating the locked object directly instead of issuing a second query.

**Database concurrency improvements:**

* The query fetching the `TokenInfo` row now uses `with_for_update()` to lock the row for update, ensuring that concurrent saves for the same `(token_id, Key)` pair are serialized and do not race. This helps prevent MariaDB error 1020 (ER_CHECKREAD) during concurrent token validations.
* The update logic now modifies the attributes of the locked `TokenInfo` object directly within the same transaction, rather than issuing a separate update query. This ensures the update applies to the row already locked and reduces the risk of inconsistencies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eduMFA/codesmith/eduMFA/pr/1202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785991244&installation_id=137412999&pr_number=1202&repository=eduMFA%2FeduMFA&return_to=https%3A%2F%2Fgithub.com%2FeduMFA%2FeduMFA%2Fpull%2F1202&signature=95ea436ee1a84a1faa63d34beb511d4946cd11d706eff02938ad218517e442c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->