### PR TITLE
chore: make smtpserver.identifier unique

### DIFF
--- a/edumfa/models.py
+++ b/edumfa/models.py
@@ -2636,7 +2636,7 @@ class SMTPServer(MethodsMixin, db.Model):
     __table_args__ = {"mysql_row_format": "DYNAMIC"}
     id = db.Column(db.Integer, Sequence("smtpserver_seq"), primary_key=True)
     # This is a name to refer to
-    identifier = db.Column(db.Unicode(255), nullable=False)
+    identifier = db.Column(db.Unicode(255), unique=True, nullable=False)
     # This is the FQDN or the IP address
     server = db.Column(db.Unicode(255), nullable=False)
     port = db.Column(db.Integer, default=25)

--- a/migrations/versions/7a1a7108fc01_.py
+++ b/migrations/versions/7a1a7108fc01_.py
@@ -1,0 +1,24 @@
+"""SMTP server are identified by their.. identifier. This field is currently not
+unique, but is enforced to be unique by application code. This migration makes
+sure it is unique at the DB level, too.
+
+Revision ID: 7a1a7108fc01
+Revises: 9cad6f046bd2
+Create Date: 2026-07-08 13:35:04.279064
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "7a1a7108fc01"
+down_revision = "9cad6f046bd2"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    op.create_unique_constraint(None, "smtpserver", ["identifier"])
+
+
+def downgrade():
+    op.drop_constraint(None, "smtpserver", type_="unique")


### PR DESCRIPTION
SMTP server are identified by their.. identifier. This field is currently not unique, but is enforced to be unique by application code. This migration makes sure it is unique at the DB level, too.  
The migration won't work on SQLite.

This PR is blocked by #1206 and has therefore broken downgrading. Fix that, and test up-/downgrading again on supported DBs.
