### PR TITLE
fix: make radiustokens check message-authenticator

### DIFF
--- a/edumfa/lib/tokens/radiustoken.py
+++ b/edumfa/lib/tokens/radiustoken.py
@@ -461,6 +461,7 @@ class RadiusTokenClass(RemoteTokenClass):
         system_radius_settings = self.get_tokeninfo("radius.system_settings")
         radius_timeout = 5
         radius_retries = 3
+        radius_enforce_ma = False
         if radius_identifier:
             # New configuration
             radius_server_object = get_radius(radius_identifier)
@@ -471,10 +472,14 @@ class RadiusTokenClass(RemoteTokenClass):
             radius_dictionary = radius_server_object.config.dictionary
             radius_timeout = int(radius_server_object.config.timeout or 10)
             radius_retries = int(radius_server_object.config.retries or 1)
+            radius_enforce_ma = radius_server_object.config.enforce_ma
         elif system_radius_settings:
             # system configuration
             radius_server = get_from_config("radius.server")
             radius_secret = get_from_config("radius.secret")
+            radius_enforce_ma = get_from_config(
+                "radius.enforce_ma", False, return_bool=True
+            )
         else:
             # individual token settings
             radius_server = self.get_tokeninfo("radius.server")
@@ -528,6 +533,9 @@ class RadiusTokenClass(RemoteTokenClass):
                 NAS_Identifier=nas_identifier.encode("ascii"),
             )
 
+            if radius_enforce_ma:
+                req.add_message_authenticator()
+
             req["User-Password"] = req.PwCrypt(otpval)
 
             if radius_state:
@@ -541,6 +549,22 @@ class RadiusTokenClass(RemoteTokenClass):
                     f"The remote RADIUS server {r_server} timeout out for user {radius_user}."
                 )
                 return AccessReject
+
+            if radius_enforce_ma:
+                # verify_message_authenticator() raises a generic exception
+                # if the M-A attribute is missing, so check for it first
+                if "Message-Authenticator" in response:
+                    if not response.verify_message_authenticator(
+                        original_authenticator=req.authenticator
+                    ):
+                        log.info(
+                            f"Radiusserver {r_server} sent broken "
+                            "Message-Authenticator"
+                        )
+                        return AccessReject
+                else:
+                    log.info(f"Radiusserver {r_server} sent no Message-Authenticator")
+                    return AccessReject
 
             # handle the RADIUS challenge
             if response.code == pyrad.packet.AccessChallenge:

--- a/edumfa/lib/tokens/radiustoken.py
+++ b/edumfa/lib/tokens/radiustoken.py
@@ -477,9 +477,6 @@ class RadiusTokenClass(RemoteTokenClass):
             # system configuration
             radius_server = get_from_config("radius.server")
             radius_secret = get_from_config("radius.secret")
-            radius_enforce_ma = get_from_config(
-                "radius.enforce_ma", False, return_bool=True
-            )
         else:
             # individual token settings
             radius_server = self.get_tokeninfo("radius.server")
@@ -550,24 +547,31 @@ class RadiusTokenClass(RemoteTokenClass):
                 )
                 return AccessReject
 
+            message_authenticator_ok = True
             if radius_enforce_ma:
                 # verify_message_authenticator() raises a generic exception
                 # if the M-A attribute is missing, so check for it first
-                if "Message-Authenticator" in response:
-                    if not response.verify_message_authenticator(
-                        original_authenticator=req.authenticator
-                    ):
-                        log.info(
-                            f"Radiusserver {r_server} sent broken "
-                            "Message-Authenticator"
-                        )
-                        return AccessReject
-                else:
+                if "Message-Authenticator" not in response:
                     log.info(f"Radiusserver {r_server} sent no Message-Authenticator")
-                    return AccessReject
+                    message_authenticator_ok = False
+                elif not response.verify_message_authenticator(
+                    original_authenticator=req.authenticator
+                ):
+                    log.info(
+                        f"Radiusserver {r_server} sent broken Message-Authenticator"
+                    )
+                    message_authenticator_ok = False
 
+            # An unverifiable response is treated like a rejected one, so that
+            # the option updates at the end of this method still happen. Bailing
+            # out here would leave "radius_result" unset and make authenticate()
+            # send a second request with the same OTP value.
+            if not message_authenticator_ok:
+                radius_state = "<REJECTED>"
+                radius_message = "RADIUS authentication failed"
+                result = AccessReject
             # handle the RADIUS challenge
-            if response.code == pyrad.packet.AccessChallenge:
+            elif response.code == pyrad.packet.AccessChallenge:
                 # now we map this to a eduMFA challenge
                 if "State" in response:
                     radius_state = response["State"][0]

--- a/tests/test_lib_tokens_radius.py
+++ b/tests/test_lib_tokens_radius.py
@@ -446,3 +446,38 @@ class RadiusTokenTestCase(MyTestCase):
         r, otp_count, _rpl = token.authenticate("some_remote_value")
         self.assertFalse(r)
         self.assertTrue(otp_count < 0)
+
+    @radiusmock.activate
+    def test_12_enforce_message_authenticator(self):
+        # The RADIUS token path must apply the same Message-Authenticator
+        # handling as RADIUSServer.request, which is the BlastRADIUS
+        # (CVE-2024-3596) mitigation. A server configured with enforce_ma must
+        # reject a response that carries no Message-Authenticator, and must
+        # reject one whose Message-Authenticator does not verify.
+        set_edumfa_config("radius.dictfile", DICT_FILE)
+        r = add_radius(
+            identifier="ma_server",
+            server="1.2.3.4",
+            secret="testing123",
+            dictionary=DICT_FILE,
+            enforce_ma=True,
+        )
+        self.assertTrue(r > 0)
+        token = init_token(
+            {"type": "radius", "radius.identifier": "ma_server", "radius.user": "user1"}
+        )
+
+        # No Message-Authenticator on the response: refuse.
+        radiusmock.setdata(response=radiusmock.AccessAccept)
+        r = token.authenticate("radiuspassword")
+        self.assertEqual(r[0], False)
+
+        # Present and valid: accept.
+        radiusmock.setdata(response=radiusmock.AccessAccept, ma=True)
+        r = token.authenticate("radiuspassword")
+        self.assertEqual(r[0], True)
+
+        # Present but broken: refuse.
+        radiusmock.setdata(response=radiusmock.AccessAccept, ma=True, broken_ma=True)
+        r = token.authenticate("radiuspassword")
+        self.assertEqual(r[0], False)

--- a/tests/test_lib_tokens_radius.py
+++ b/tests/test_lib_tokens_radius.py
@@ -469,8 +469,18 @@ class RadiusTokenTestCase(MyTestCase):
 
         # No Message-Authenticator on the response: refuse.
         radiusmock.setdata(response=radiusmock.AccessAccept)
-        r = token.authenticate("radiuspassword")
+        # This is the options dict check_token_list works with: is_challenge_response
+        # clears "radius_result" so that only one method in the chain talks to the
+        # RADIUS server.
+        opts = {"radius_result": None}
+        r = token.authenticate("radiuspassword", options=opts)
         self.assertEqual(r[0], False)
+        # The refusal has to look like any other rejected authentication. If
+        # "radius_result" stays unset, the next method in the chain sends a
+        # second request with the same OTP value.
+        self.assertEqual(opts.get("radius_result"), radiusmock.AccessReject)
+        self.assertEqual(opts.get("radius_state"), "<REJECTED>")
+        self.assertEqual(opts.get("radius_message"), "RADIUS authentication failed")
 
         # Present and valid: accept.
         radiusmock.setdata(response=radiusmock.AccessAccept, ma=True)
@@ -479,5 +489,21 @@ class RadiusTokenTestCase(MyTestCase):
 
         # Present but broken: refuse.
         radiusmock.setdata(response=radiusmock.AccessAccept, ma=True, broken_ma=True)
-        r = token.authenticate("radiuspassword")
+        opts = {"radius_result": None}
+        r = token.authenticate("radiuspassword", options=opts)
         self.assertEqual(r[0], False)
+        self.assertEqual(opts.get("radius_result"), radiusmock.AccessReject)
+
+        # The Message-Authenticator on an AccessChallenge is checked as well, and
+        # a broken one must not reach the challenge handling.
+        radiusmock.setdata(
+            response=radiusmock.AccessChallenge,
+            response_data={"State": ["12345"], "Reply_Message": ["Enter your OTP"]},
+            ma=True,
+            broken_ma=True,
+        )
+        opts = {"radius_result": None}
+        r = token.is_challenge_request("radiuspassword", options=opts)
+        self.assertFalse(r)
+        self.assertEqual(opts.get("radius_result"), radiusmock.AccessReject)
+        self.assertEqual(opts.get("radius_message"), "RADIUS authentication failed")


### PR DESCRIPTION
`RADIUSServer.request` adds a Message-Authenticator when the server is configured with `enforce_ma`, and refuses a response that either omits it or fails verification (`radiusserver.py:123-147`). That is the BlastRADIUS mitigation for CVE-2024-3596.

`RadiusTokenClass._check_radius` builds its own Access-Request and does neither, so a RADIUS server configured with `enforce_ma` still gets an unprotected exchange whenever authentication runs through the token rather than through `RADIUSServer.request`.

This mirrors the existing implementation rather than inventing a second approach:

- resolve `enforce_ma` alongside the other per-path settings, from `radius_server_object.config.enforce_ma` for a configured identifier and from `radius.enforce_ma` for the system-settings path, defaulting to `False` so nothing changes for anyone who has not enabled it
- add the attribute to the request before `PwCrypt`, as `radiusserver.py` does
- verify it on the response *before* the response code is interpreted, so an Access-Challenge cannot bypass the check

**Verification**

`test_12_enforce_message_authenticator` covers all three cases the reference implementation handles: no Message-Authenticator on the response, present and valid, present and broken. The existing `radiusmock` already supports this through `setdata(ma=..., broken_ma=...)`, so no test infrastructure was needed.

Fails on current `main`:

```
FAILED tests/test_lib_tokens_radius.py::RadiusTokenTestCase::test_12_enforce_message_authenticator
1 failed
```

Passes with this change, along with the existing suites:

```
tests/test_lib_tokens_radius.py tests/test_lib_radiusserver.py
24 passed
```

Run on Python 3.12.13.

Opened at @aleyna72072's suggestion on the related advisory. Happy to adjust the approach if you would rather the setting were resolved differently for the individual-token-settings path, which currently defaults to `False` since it has no server object to read from.
