### PR TITLE
docs: add release process tooling and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,9 @@ make translate-backend
 The following section describes our development workflow: How do we handle
 issues, how do we develop eduMFA, how do we perform code reviews?
 
+Members of the release team should also follow the
+[release checklist](RELEASE.md).
+
 ### Terminology
 
 In the following, *"we"* and *"team"* refers to the [eduMFA development
@@ -192,11 +195,10 @@ consequence, may be unstable. Features are usually added there.
 
 ##### Stable branches
 
-For each minor version ``X.Y`` (e.g. 2.23, 3.0, ...), we create a *stable
-branch* called ``branch-X.Y``, e.g.
-[``branch-3.0``](https://github.com/eduMFA/eduMFA/tree/branch-3.0).
-Hotfixes for stable versions are usually added to the stable branches. Stable
-branches are then merged back into the main branch.
+For each maintained major/minor version ``X.Y`` (e.g. 2.9, 3.0, ...), we create
+a *fix branch* called ``vX.Y.x``, e.g. ``v2.9.x``. Fixes are developed on
+``main`` and the commits intended for a fix release are cherry-picked into the
+fix branch. See the [release checklist](RELEASE.md) for the complete process.
 
 ##### Local Branches and Pull Requests
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ info:
 	@echo "make translate-frontend	- translate WebUI"
 	@echo "make translate-backend 	- translate string in the server code."
 	@echo "make update-contrib   	- update JS contrib libraries"
+	@echo "make prepare-release VERSION=X.Y.Z"
+	@echo "make prepare-fix-release VERSION=X.Y.Z COMMITS='sha1 sha2'"
+	@echo "make check-release VERSION=X.Y.Z"
+	@echo "make tag-release VERSION=X.Y.Z"
+	@echo "make create-fix-branch VERSION=X.Y.0"
+	@echo "make start-development VERSION=X.Y.Za"
 
 
 BUN_VERSION := $(shell bun --version 2>/dev/null)
@@ -16,13 +22,32 @@ clean:
 	rm -f .coverage
 	(cd doc; make clean)
 
-setversion:
-	vim Makefile
-	vim setup.py
-	vim doc/conf.py
-	vim Changelog
-	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-	@echo "Please set a tag like:  git tag 3.17"
+.PHONY: prepare-release prepare-fix-release check-release tag-release create-fix-branch start-development
+
+prepare-release: check-uv
+	@test -n "$(VERSION)" || (echo "VERSION is required, for example VERSION=2.10.0"; exit 2)
+	uv run --no-sync python tools/release.py prepare --version "$(VERSION)"
+
+prepare-fix-release: check-uv
+	@test -n "$(VERSION)" || (echo "VERSION is required, for example VERSION=2.9.4"; exit 2)
+	@test -n "$(COMMITS)" || (echo "COMMITS is required, for example COMMITS='abc123 def456'"; exit 2)
+	uv run --no-sync python tools/release.py prepare-fix --version "$(VERSION)" --commits "$(COMMITS)"
+
+check-release: check-uv
+	@test -n "$(VERSION)" || (echo "VERSION is required, for example VERSION=2.10.0"; exit 2)
+	uv run --no-sync python tools/release.py check --version "$(VERSION)"
+
+tag-release: check-uv
+	@test -n "$(VERSION)" || (echo "VERSION is required, for example VERSION=2.10.0"; exit 2)
+	uv run --no-sync python tools/release.py tag --version "$(VERSION)"
+
+create-fix-branch: check-uv
+	@test -n "$(VERSION)" || (echo "VERSION is required, for example VERSION=2.10.0"; exit 2)
+	uv run --no-sync python tools/release.py create-fix-branch --version "$(VERSION)"
+
+start-development: check-uv
+	@test -n "$(VERSION)" || (echo "VERSION is required, for example VERSION=2.11.0a"; exit 2)
+	uv run --no-sync python tools/release.py start-development --version "$(VERSION)"
 
 doc-man:
 	(cd doc; make man)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -194,7 +194,11 @@ been checked:
    installation and an upgrade from the preceding release.
 6. Confirm that Read the Docs built `vX.Y.Z` and rendered the changelog and
    upgrade instructions correctly.
-7. Close the milestone and announce the release through the usual channels.
+7. Open the [eduMFA documentation landing page](https://edumfa.readthedocs.io/)
+   and confirm that it redirects to `/en/vX.Y.Z/` and displays
+   `eduMFA X.Y.Z documentation`. If it still points to the previous release,
+   update the default version in Read the Docs before announcing the release.
+8. Close the milestone and announce the release through the usual channels.
 
 If publication fails transiently, re-run only the failed job and repeat the
 verification. PyPI releases and container tags may already be public when a

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,202 @@
+# Making an eduMFA release
+
+This document is the release checklist for eduMFA maintainers. The release
+tooling is exposed through `make`; run `make info` to list the available
+commands.
+
+The examples use:
+
+- `X.Y.Z` for the release version;
+- `vX.Y.Z` for its Git tag;
+- `vX.Y.x` for the corresponding fix branch; and
+- `PREVIOUS` for the preceding release tag.
+
+## What the tooling does
+
+The Make targets automate repeatable repository changes and reject inconsistent
+release state:
+
+| Command | Purpose |
+| --- | --- |
+| `make prepare-release VERSION=X.Y.Z` | Update release versions, Ubuntu changelogs, and `uv.lock`, then check consistency |
+| `make prepare-fix-release VERSION=X.Y.Z COMMITS="sha1 sha2"` | Verify the fix branch, cherry-pick approved commits, and prepare the release |
+| `make check-release VERSION=X.Y.Z` | Check the changelog and every release version without changing files |
+| `make tag-release VERSION=X.Y.Z` | Check the release and create a local tag at the published branch tip |
+| `make create-fix-branch VERSION=X.Y.0` | Create a local `vX.Y.x` branch from the local release tag |
+| `make start-development VERSION=X.Y.Za` | Set the next development version and refresh `uv.lock` |
+
+The tooling does **not** write release notes, resolve cherry-pick conflicts,
+commit changes, push branches or tags, publish artifacts, or announce a
+release. These remain deliberate maintainer actions.
+
+## Before every release
+
+1. Assign all intended issues to the release milestone.
+2. Confirm that no release blockers remain and all required migrations are
+   included.
+3. Add an `eduMFA X.Y.Z` section to `doc/changelog.rst`. Include user-visible
+   changes, upgrade warnings, permitted security information, and a comparison
+   link from `PREVIOUS` to `vX.Y.Z`.
+4. Have another maintainer review the scope and release notes.
+
+The changelog must exist before running a preparation target. For a major or
+minor release it may be an uncommitted local change. For a fix release it must
+already be committed on `vX.Y.x` or be included in one of the commits selected
+for cherry-picking, because fix preparation starts from a clean working tree.
+
+## Major or minor release
+
+Major and minor releases are prepared on `main`.
+
+### 1. Prepare the release
+
+Update local `main`, write the changelog, and run:
+
+```console
+$ git switch main
+$ git pull --ff-only origin main
+$ make prepare-release VERSION=X.Y.0
+$ git diff
+```
+
+`prepare-release` performs the following changes:
+
+- sets `project.version` in `pyproject.toml`;
+- sets `version` and `release` in `doc/conf.py`;
+- prepends entries to `deploy/ubuntu/changelog` and
+  `deploy/ubuntu-server/changelog`;
+- refreshes `uv.lock`; and
+- verifies that these versions and the changelog agree.
+
+The `edumfa-radius` Debian package has an independent version. Update
+`deploy/ubuntu-radius/changelog` manually only when that package itself is
+released.
+
+Review the diff, run the normal lint and test suites, and build and inspect the
+documentation and distribution artifacts. Then create a release commit and
+push it through the normal review process:
+
+```console
+$ git commit -am "chore(release): prepare X.Y.0 release"
+$ git push
+```
+
+Before tagging, the reviewed release commit must be the tip of `origin/main`.
+
+### 2. Check and tag
+
+```console
+$ git switch main
+$ git pull --ff-only origin main
+$ make check-release VERSION=X.Y.0
+$ make tag-release VERSION=X.Y.0
+$ git push origin vX.Y.0
+```
+
+`tag-release` creates the tag locally. It refuses to tag a dirty tree, the
+wrong branch, an unpublished branch tip, inconsistent versions, or an existing
+tag. The final `git push` is intentionally manual because it starts publication.
+
+### 3. Create the fix branch
+
+If the release series will receive fixes, create its maintenance branch from
+the release tag before changing the version on `main`:
+
+```console
+$ make create-fix-branch VERSION=X.Y.0
+$ git push origin vX.Y.x
+```
+
+### 4. Start the next development cycle
+
+Switch back to `main` and move it to the next minor alpha version. For example,
+after releasing `2.9.0`, continue as `2.10.0a`:
+
+```console
+$ git switch main
+$ make start-development VERSION=2.10.0a
+$ git diff
+$ git commit -am "chore: start 2.10 development"
+$ git push
+```
+
+Do not apply the development-version bump to `vX.Y.x`.
+
+## Fix release
+
+Fixes are developed and reviewed on `main`, then selected commits are
+cherry-picked into `vX.Y.x`. Only include fixes approved for the release, in
+dependency order. Avoid unrelated refactors and dependency updates.
+
+### 1. Prepare the fix branch
+
+Ensure the changelog is committed on the fix branch or included in the selected
+commits. Start from a clean and current maintenance branch:
+
+```console
+$ git switch vX.Y.x
+$ git pull --ff-only origin vX.Y.x
+$ git status --short
+$ make prepare-fix-release VERSION=X.Y.Z COMMITS="sha1 sha2"
+$ git diff
+```
+
+The target verifies that `Z` is non-zero, the current branch is `vX.Y.x`, the
+working tree is clean, and every selected commit belongs to `main`. It then
+cherry-picks the commits in the supplied order and performs the same preparation
+and consistency checks as `prepare-release`.
+
+If a cherry-pick conflicts, the command stops. Resolve or abort the cherry-pick
+using Git; after resolving it, run `make prepare-release VERSION=X.Y.Z` to
+finish the version preparation. Do not repeat `prepare-fix-release`, because
+that would attempt to cherry-pick the commits again.
+
+Review and test the complete branch, not only its individual commits. Commit
+the generated release changes and push them through the normal review process:
+
+```console
+$ git commit -am "chore(release): prepare X.Y.Z release"
+$ git push
+```
+
+### 2. Check and tag
+
+After the reviewed release commit is the tip of `origin/vX.Y.x`:
+
+```console
+$ git switch vX.Y.x
+$ git pull --ff-only origin vX.Y.x
+$ make check-release VERSION=X.Y.Z
+$ make tag-release VERSION=X.Y.Z
+$ git push origin vX.Y.Z
+```
+
+A fix release does not require a development-version bump on `main`.
+
+## Publication and verification
+
+Pushing `vX.Y.Z` starts the existing GitHub Actions workflows:
+
+| Workflow | Published artifacts |
+| --- | --- |
+| `publish` | Wheel and source archive on the GitHub release and PyPI |
+| `docker` | Multi-architecture image on GHCR |
+| `ubuntu` | Ubuntu packages for the supported releases in the package repository |
+
+Do not announce the release until all tag-triggered runs and artifacts have
+been checked:
+
+1. Confirm that `publish`, `docker`, and `ubuntu` succeeded for the tag.
+2. Review the GitHub release notes and verify both Python distribution files.
+3. Confirm that `edumfa==X.Y.Z` can be installed from PyPI.
+4. Pull `ghcr.io/edumfa/edumfa:X.Y.Z` and check its application version.
+5. Test the Ubuntu packages for every supported repository, including a fresh
+   installation and an upgrade from the preceding release.
+6. Confirm that Read the Docs built `vX.Y.Z` and rendered the changelog and
+   upgrade instructions correctly.
+7. Close the milestone and announce the release through the usual channels.
+
+If publication fails transiently, re-run only the failed job and repeat the
+verification. PyPI releases and container tags may already be public when a
+later job fails. Never move a published tag or replace a published artifact;
+fix a release defect with a new fix release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,7 @@ release state:
 | --- | --- |
 | `make prepare-release VERSION=X.Y.Z` | Update release versions, Ubuntu changelogs, and `uv.lock`, then check consistency |
 | `make prepare-fix-release VERSION=X.Y.Z COMMITS="sha1 sha2"` | Verify the fix branch, cherry-pick approved commits, and prepare the release |
-| `make check-release VERSION=X.Y.Z` | Check the changelog and every release version without changing files |
+| `make check-release VERSION=X.Y.Z` | Check release metadata, the lockfile, and the complete dependency environment without changing resolution |
 | `make tag-release VERSION=X.Y.Z` | Check the release and create a local tag at the published branch tip |
 | `make create-fix-branch VERSION=X.Y.0` | Create a local `vX.Y.x` branch from the local release tag |
 | `make start-development VERSION=X.Y.Za` | Set the next development version and refresh `uv.lock` |
@@ -66,7 +66,15 @@ $ git diff
 - prepends entries to `deploy/ubuntu/changelog` and
   `deploy/ubuntu-server/changelog`;
 - refreshes `uv.lock`; and
-- verifies that these versions and the changelog agree.
+- verifies that these versions and the changelog agree; and
+- runs the immutable dependency checks described below.
+
+The dependency check runs `uv lock --check` followed by
+`uv sync --locked --all-groups`. It fails if `uv.lock` is stale, dependency
+resolution is unsatisfiable, or any dependency group cannot be installed. The
+locked mode prevents release validation from silently changing the committed
+resolution. Dependency upgrades must therefore include every related update
+needed to keep the complete dependency set compatible.
 
 The `edumfa-radius` Debian package has an independent version. Update
 `deploy/ubuntu-radius/changelog` manually only when that package itself is
@@ -93,9 +101,11 @@ $ make tag-release VERSION=X.Y.0
 $ git push origin vX.Y.0
 ```
 
-`tag-release` creates the tag locally. It refuses to tag a dirty tree, the
-wrong branch, an unpublished branch tip, inconsistent versions, or an existing
-tag. The final `git push` is intentionally manual because it starts publication.
+`tag-release` runs the complete release and dependency checks before creating
+the tag locally. It refuses to tag a dirty tree, the wrong branch, an
+unpublished branch tip, inconsistent versions, incompatible dependencies, or
+an existing tag. The final `git push` is intentionally manual because it starts
+publication.
 
 ### 3. Create the fix branch
 
@@ -126,7 +136,9 @@ Do not apply the development-version bump to `vX.Y.x`.
 
 Fixes are developed and reviewed on `main`, then selected commits are
 cherry-picked into `vX.Y.x`. Only include fixes approved for the release, in
-dependency order. Avoid unrelated refactors and dependency updates.
+dependency order. Avoid unrelated refactors and dependency updates. A dependency
+or security update must, however, be cherry-picked together with every
+compatibility update required for a valid dependency resolution.
 
 ### 1. Prepare the fix branch
 

--- a/tests/test_release_tool.py
+++ b/tests/test_release_tool.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def load_release_module() -> ModuleType:
+    script = Path(__file__).parents[1] / "tools" / "release.py"
+    spec = importlib.util.spec_from_file_location("release_tool", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def release_tool(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    module = load_release_module()
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+    files = {
+        "pyproject.toml": '[project]\nname = "edumfa"\nversion = "2.10.0a"\n',
+        "uv.lock": '[[package]]\nname = "edumfa"\nversion = "2.10.0a0"\n',
+        "doc/conf.py": 'version = "2.10.0"\nrelease = "2.10.0a"\n',
+        "doc/changelog.rst": "eduMFA 2.10.0\n----------------\n\nHighlights\n",
+        "deploy/ubuntu/changelog": "edumfa (2.9.3{{CODENAME}}) {{CODENAME}}; urgency=high\n",
+        "deploy/ubuntu-server/changelog": (
+            "edumfa-server (2.9.3{{CODENAME}}) {{CODENAME}}; urgency=high\n"
+        ),
+    }
+    for relative_path, content in files.items():
+        destination = tmp_path / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(content, encoding="utf-8")
+
+    def refresh_lock() -> None:
+        version = module.project_version()
+        module.write_text(
+            Path("uv.lock"),
+            f'[[package]]\nname = "edumfa"\nversion = "{version}"\n',
+        )
+
+    monkeypatch.setattr(module, "refresh_lock", refresh_lock)
+    return module
+
+
+def test_prepare_release_updates_every_version(release_tool: ModuleType) -> None:
+    release_tool.prepare_release("2.10.0")
+
+    assert release_tool.project_version() == "2.10.0"
+    assert release_tool.configured_doc_versions() == ("2.10.0", "2.10.0")
+    assert release_tool.read_text(release_tool.UBUNTU_CHANGELOG).startswith(
+        "edumfa (2.10.0{{CODENAME}})"
+    )
+    assert release_tool.read_text(release_tool.UBUNTU_SERVER_CHANGELOG).startswith(
+        "edumfa-server (2.10.0{{CODENAME}})"
+    )
+
+
+def test_prepare_release_can_be_repeated_without_duplicate_entries(
+    release_tool: ModuleType,
+) -> None:
+    release_tool.prepare_release("2.10.0")
+    release_tool.prepare_release("2.10.0")
+
+    assert (
+        release_tool.read_text(release_tool.UBUNTU_CHANGELOG).count(
+            "edumfa (2.10.0{{CODENAME}})"
+        )
+        == 1
+    )
+
+
+def test_prepare_release_requires_changelog_section(release_tool: ModuleType) -> None:
+    release_tool.write_text(release_tool.CHANGELOG, "Changelog\n=========\n")
+
+    with pytest.raises(
+        release_tool.ReleaseError, match="Add the 'eduMFA 2.10.0' section"
+    ):
+        release_tool.prepare_release("2.10.0")
+
+
+@pytest.mark.parametrize("version", ["2.10", "v2.10.0", "2.10.0a"])
+def test_final_version_is_strict(release_tool: ModuleType, version: str) -> None:
+    with pytest.raises(release_tool.ReleaseError):
+        release_tool.require_final_version(version)
+
+
+def test_development_version_must_be_alpha(release_tool: ModuleType) -> None:
+    with pytest.raises(release_tool.ReleaseError):
+        release_tool.start_development("2.11.0")
+
+
+def test_fix_release_must_be_tagged_on_maintenance_branch(
+    release_tool: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    release_tool.write_text(
+        release_tool.CHANGELOG,
+        "eduMFA 2.10.1\n----------------\n\nBug Fixes\n",
+    )
+    release_tool.prepare_release("2.10.1")
+
+    def fake_git(arguments: list[str], *, capture_output: bool = False) -> str:
+        del capture_output
+        if arguments == ["branch", "--show-current"]:
+            return "main"
+        return ""
+
+    monkeypatch.setattr(release_tool, "run_git", fake_git)
+
+    with pytest.raises(release_tool.ReleaseError, match="must be tagged on v2.10.x"):
+        release_tool.tag_release("2.10.1")
+
+
+def test_create_fix_branch_uses_release_tag(
+    release_tool: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_git(arguments: list[str], *, capture_output: bool = False) -> str:
+        del capture_output
+        calls.append(arguments)
+        if arguments == ["tag", "--list", "v2.10.0"]:
+            return "v2.10.0"
+        return ""
+
+    monkeypatch.setattr(release_tool, "run_git", fake_git)
+
+    release_tool.create_fix_branch("2.10.0")
+
+    assert ["branch", "v2.10.x", "v2.10.0"] in calls

--- a/tests/test_release_tool.py
+++ b/tests/test_release_tool.py
@@ -44,6 +44,7 @@ def release_tool(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ModuleType:
         )
 
     monkeypatch.setattr(module, "refresh_lock", refresh_lock)
+    monkeypatch.setattr(module, "verify_dependencies", lambda: None)
     return module
 
 
@@ -81,6 +82,40 @@ def test_prepare_release_requires_changelog_section(release_tool: ModuleType) ->
         release_tool.ReleaseError, match="Add the 'eduMFA 2.10.0' section"
     ):
         release_tool.prepare_release("2.10.0")
+
+
+def test_dependency_check_uses_locked_complete_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    release_tool = load_release_module()
+    monkeypatch.setattr(release_tool, "ROOT", tmp_path)
+    commands: list[list[str]] = []
+
+    def run(arguments: list[str], *, cwd: Path, check: bool) -> None:
+        assert cwd == release_tool.ROOT
+        assert check is True
+        commands.append(arguments)
+
+    monkeypatch.setattr(release_tool.subprocess, "run", run)
+
+    release_tool.verify_dependencies()
+
+    assert commands == [
+        ["uv", "lock", "--check"],
+        ["uv", "sync", "--locked", "--all-groups"],
+    ]
+
+
+def test_release_check_verifies_dependencies(
+    release_tool: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    release_tool.prepare_release("2.10.0")
+    calls: list[None] = []
+    monkeypatch.setattr(release_tool, "verify_dependencies", lambda: calls.append(None))
+
+    release_tool.check_release("2.10.0")
+
+    assert calls == [None]
 
 
 @pytest.mark.parametrize("version", ["2.10", "v2.10.0", "2.10.0a"])

--- a/tools/release.py
+++ b/tools/release.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Prepare and validate eduMFA releases."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import NoReturn, cast
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = Path("pyproject.toml")
+DOC_CONFIG = Path("doc/conf.py")
+CHANGELOG = Path("doc/changelog.rst")
+UBUNTU_CHANGELOG = Path("deploy/ubuntu/changelog")
+UBUNTU_SERVER_CHANGELOG = Path("deploy/ubuntu-server/changelog")
+
+FINAL_VERSION = re.compile(
+    r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$"
+)
+DEVELOPMENT_VERSION = re.compile(
+    r"^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)a\d*$"
+)
+
+
+class ReleaseError(Exception):
+    """A release precondition was not met."""
+
+
+def repository_path(relative_path: Path) -> Path:
+    return ROOT / relative_path
+
+
+def read_text(relative_path: Path) -> str:
+    return repository_path(relative_path).read_text(encoding="utf-8")
+
+
+def write_text(relative_path: Path, content: str) -> None:
+    repository_path(relative_path).write_text(content, encoding="utf-8")
+
+
+def run_git(arguments: Sequence[str], *, capture_output: bool = False) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        capture_output=capture_output,
+    )
+    return result.stdout.strip() if capture_output else ""
+
+
+def require_final_version(version: str) -> re.Match[str]:
+    match = FINAL_VERSION.fullmatch(version)
+    if match is None:
+        raise ReleaseError(f"Expected a final version such as 2.10.0, got {version!r}")
+    return match
+
+
+def require_development_version(version: str) -> None:
+    if DEVELOPMENT_VERSION.fullmatch(version) is None:
+        raise ReleaseError(
+            f"Expected an alpha development version such as 2.11.0a, got {version!r}"
+        )
+
+
+def replace_once(relative_path: Path, pattern: str, replacement: str) -> None:
+    content = read_text(relative_path)
+    updated, count = re.subn(pattern, replacement, content, count=1, flags=re.MULTILINE)
+    if count != 1:
+        raise ReleaseError(
+            f"Could not find exactly one version field in {relative_path}"
+        )
+    write_text(relative_path, updated)
+
+
+def set_python_versions(version: str) -> None:
+    replace_once(PYPROJECT, r'^version = "[^"]+"$', f'version = "{version}"')
+    replace_once(DOC_CONFIG, r'^version = "[^"]+"$', f'version = "{version}"')
+    replace_once(
+        DOC_CONFIG, r'^release = (?:version|"[^"]+")$', f'release = "{version}"'
+    )
+
+
+def changelog_anchor(version: str) -> str:
+    return f"edumfa-{version.replace('.', '-')}"
+
+
+def require_changelog_section(version: str) -> None:
+    heading = f"eduMFA {version}"
+    lines = read_text(CHANGELOG).splitlines()
+    for index, line in enumerate(lines[:-1]):
+        if line == heading and lines[index + 1] and set(lines[index + 1]) == {"-"}:
+            return
+    raise ReleaseError(
+        f"Add the {heading!r} section to {CHANGELOG} before preparing the release"
+    )
+
+
+def debian_timestamp() -> str:
+    return datetime.now().astimezone().strftime("%a, %-d %b %Y %H:%M:%S %z")
+
+
+def prepend_ubuntu_changelogs(version: str) -> None:
+    timestamp = debian_timestamp()
+    core_entry = (
+        f"edumfa ({version}{{{{CODENAME}}}}) {{{{CODENAME}}}}; urgency=high\n\n"
+        f"  * See the changelog for the {version} release at:\n"
+        f"    https://edumfa.readthedocs.io/en/latest/changelog.html#{changelog_anchor(version)}\n\n"
+        f" -- eduMFA <edumfa-dev@listserv.dfn.de>  {timestamp}\n\n"
+    )
+    server_entry = (
+        f"edumfa-server ({version}{{{{CODENAME}}}}) {{{{CODENAME}}}}; urgency=high\n\n"
+        "  * Update version number.\n\n"
+        f" -- eduMFA <edumfa-dev@listserv.dfn.de>  {timestamp}\n\n"
+    )
+    write_text(UBUNTU_CHANGELOG, core_entry + read_text(UBUNTU_CHANGELOG))
+    write_text(
+        UBUNTU_SERVER_CHANGELOG, server_entry + read_text(UBUNTU_SERVER_CHANGELOG)
+    )
+
+
+def refresh_lock() -> None:
+    subprocess.run(["uv", "lock"], cwd=ROOT, check=True)
+
+
+def project_version() -> str:
+    match = re.search(r'^version = "([^"]+)"$', read_text(PYPROJECT), re.MULTILINE)
+    if match is None:
+        raise ReleaseError("project.version is missing from pyproject.toml")
+    return match.group(1)
+
+
+def locked_project_version() -> str:
+    match = re.search(
+        r'^\[\[package\]\]\nname = "edumfa"\nversion = "([^"]+)"$',
+        read_text(Path("uv.lock")),
+        re.MULTILINE,
+    )
+    if match is None:
+        raise ReleaseError("The eduMFA package version is missing from uv.lock")
+    return match.group(1)
+
+
+def configured_doc_versions() -> tuple[str, str]:
+    content = read_text(DOC_CONFIG)
+    version_match = re.search(r'^version = "([^"]+)"$', content, re.MULTILINE)
+    release_match = re.search(r'^release = "([^"]+)"$', content, re.MULTILINE)
+    if version_match is None or release_match is None:
+        raise ReleaseError(
+            "doc/conf.py must contain literal version and release values"
+        )
+    return version_match.group(1), release_match.group(1)
+
+
+def check_release(version: str) -> None:
+    require_final_version(version)
+    require_changelog_section(version)
+    values = {
+        "pyproject.toml": project_version(),
+        "uv.lock": locked_project_version(),
+        "doc/conf.py version": configured_doc_versions()[0],
+        "doc/conf.py release": configured_doc_versions()[1],
+    }
+    mismatches = [
+        f"{name}: {value}" for name, value in values.items() if value != version
+    ]
+    expected_core = f"edumfa ({version}{{{{CODENAME}}}})"
+    expected_server = f"edumfa-server ({version}{{{{CODENAME}}}})"
+    if not read_text(UBUNTU_CHANGELOG).startswith(expected_core):
+        mismatches.append(f"{UBUNTU_CHANGELOG}: does not start with {expected_core!r}")
+    if not read_text(UBUNTU_SERVER_CHANGELOG).startswith(expected_server):
+        mismatches.append(
+            f"{UBUNTU_SERVER_CHANGELOG}: does not start with {expected_server!r}"
+        )
+    if mismatches:
+        raise ReleaseError(
+            "Release versions are inconsistent:\n  " + "\n  ".join(mismatches)
+        )
+    print(f"Release {version} is consistent.")
+
+
+def prepare_release(version: str) -> None:
+    require_final_version(version)
+    require_changelog_section(version)
+    expected_core = f"edumfa ({version}{{{{CODENAME}}}})"
+    expected_server = f"edumfa-server ({version}{{{{CODENAME}}}})"
+    core_prepared = read_text(UBUNTU_CHANGELOG).startswith(expected_core)
+    server_prepared = read_text(UBUNTU_SERVER_CHANGELOG).startswith(expected_server)
+    if core_prepared != server_prepared:
+        raise ReleaseError(
+            "Only one Ubuntu changelog contains the release; repair them before continuing"
+        )
+    set_python_versions(version)
+    if not core_prepared:
+        prepend_ubuntu_changelogs(version)
+    refresh_lock()
+    check_release(version)
+    print("Review and commit the release changes, then run:")
+    print(f"  make tag-release VERSION={version}")
+
+
+def prepare_fix_release(version: str, commits: Sequence[str]) -> None:
+    match = require_final_version(version)
+    if int(match.group("patch")) == 0:
+        raise ReleaseError("A fix release must have a non-zero patch version")
+    expected_branch = f"v{match.group('major')}.{match.group('minor')}.x"
+    branch = run_git(["branch", "--show-current"], capture_output=True)
+    if branch != expected_branch:
+        raise ReleaseError(
+            f"Fix release {version} must be prepared on {expected_branch}, not {branch}"
+        )
+    if not commits:
+        raise ReleaseError("At least one commit is required for a fix release")
+    if run_git(["status", "--porcelain"], capture_output=True):
+        raise ReleaseError("The working tree must be clean before cherry-picking fixes")
+    for commit in commits:
+        run_git(["merge-base", "--is-ancestor", commit, "main"])
+    run_git(["cherry-pick", *commits])
+    prepare_release(version)
+
+
+def start_development(version: str) -> None:
+    require_development_version(version)
+    set_python_versions(version)
+    refresh_lock()
+    print(f"Development version changed to {version}.")
+
+
+def tag_release(version: str) -> None:
+    check_release(version)
+    match = require_final_version(version)
+    branch = run_git(["branch", "--show-current"], capture_output=True)
+    expected_branch = (
+        "main"
+        if int(match.group("patch")) == 0
+        else f"v{match.group('major')}.{match.group('minor')}.x"
+    )
+    if branch != expected_branch:
+        raise ReleaseError(
+            f"Release {version} must be tagged on {expected_branch}, not {branch}"
+        )
+    if run_git(["status", "--porcelain"], capture_output=True):
+        raise ReleaseError("Commit the release changes before creating the tag")
+    head = run_git(["rev-parse", "HEAD"], capture_output=True)
+    remote_branch = run_git(
+        ["ls-remote", "--heads", "origin", f"refs/heads/{expected_branch}"],
+        capture_output=True,
+    )
+    remote_head = remote_branch.partition("\t")[0]
+    if not remote_head:
+        raise ReleaseError(f"Branch {expected_branch} does not exist on origin")
+    if head != remote_head:
+        raise ReleaseError(
+            f"HEAD is not the published tip of origin/{expected_branch}; push or update the branch first"
+        )
+    tag = f"v{version}"
+    local_tag = run_git(["tag", "--list", tag], capture_output=True)
+    remote_tag = run_git(
+        ["ls-remote", "--tags", "origin", f"refs/tags/{tag}"], capture_output=True
+    )
+    if local_tag or remote_tag:
+        raise ReleaseError(f"Tag {tag} already exists")
+    run_git(["tag", tag])
+    print(f"Created {tag} at the current commit. Review it, then publish with:")
+    print(f"  git push origin {tag}")
+
+
+def create_fix_branch(version: str) -> None:
+    match = require_final_version(version)
+    if int(match.group("patch")) != 0:
+        raise ReleaseError("Create a fix branch from a major or minor X.Y.0 release")
+    tag = f"v{version}"
+    branch = f"v{match.group('major')}.{match.group('minor')}.x"
+    if not run_git(["tag", "--list", tag], capture_output=True):
+        raise ReleaseError(f"Release tag {tag} does not exist locally")
+    if run_git(["branch", "--list", branch], capture_output=True):
+        raise ReleaseError(f"Branch {branch} already exists locally")
+    if run_git(
+        ["ls-remote", "--heads", "origin", f"refs/heads/{branch}"],
+        capture_output=True,
+    ):
+        raise ReleaseError(f"Branch {branch} already exists on origin")
+    run_git(["branch", branch, tag])
+    print(f"Created {branch} from {tag}. Review it, then publish with:")
+    print(f"  git push origin {branch}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in (
+        "prepare",
+        "check",
+        "tag",
+        "create-fix-branch",
+        "start-development",
+    ):
+        command_parser = subparsers.add_parser(command)
+        command_parser.add_argument("--version", required=True)
+    fix_parser = subparsers.add_parser("prepare-fix")
+    fix_parser.add_argument("--version", required=True)
+    fix_parser.add_argument("--commits", required=True)
+    return parser
+
+
+def fail(message: str) -> NoReturn:
+    print(f"release: error: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    namespace = build_parser().parse_args(arguments)
+    command = cast(str, namespace.command)
+    version = cast(str, namespace.version)
+    try:
+        if command == "prepare":
+            prepare_release(version)
+        elif command == "prepare-fix":
+            prepare_fix_release(version, cast(str, namespace.commits).split())
+        elif command == "check":
+            check_release(version)
+        elif command == "tag":
+            tag_release(version)
+        elif command == "create-fix-branch":
+            create_fix_branch(version)
+        elif command == "start-development":
+            start_development(version)
+        else:
+            fail(f"Unknown command {command!r}")
+    except (ReleaseError, subprocess.CalledProcessError) as error:
+        fail(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/release.py
+++ b/tools/release.py
@@ -157,6 +157,11 @@ def configured_doc_versions() -> tuple[str, str]:
     return version_match.group(1), release_match.group(1)
 
 
+def verify_dependencies() -> None:
+    subprocess.run(["uv", "lock", "--check"], cwd=ROOT, check=True)
+    subprocess.run(["uv", "sync", "--locked", "--all-groups"], cwd=ROOT, check=True)
+
+
 def check_release(version: str) -> None:
     require_final_version(version)
     require_changelog_section(version)
@@ -181,6 +186,7 @@ def check_release(version: str) -> None:
         raise ReleaseError(
             "Release versions are inconsistent:\n  " + "\n  ".join(mismatches)
         )
+    verify_dependencies()
     print(f"Release {version} is consistent.")
 
 


### PR DESCRIPTION
This PR implements issue #1148 by adding docs for the release process as `RELEASE.md`. For simplification I also added tooling that's accessible trough the makefile that manages all release related tasks.