### PR TITLE
chore: update changelog for v2.9.5

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -15,6 +15,12 @@ For version-to-version upgrade steps, see :ref:`migration_guides`.
 
    This is tracked in `issue #1124 <https://github.com/eduMFA/eduMFA/issues/1124>`_.
 
+eduMFA 2.9.5
+------------
+
+This release contains no functional changes but fixes an issue with uploading
+to PyPi. This causes version 2.9.4 to not be available there.
+
 eduMFA 2.9.4
 ------------
 


### PR DESCRIPTION
Adds the changelog for the v2.9.5 release.

<img width="972" height="126" alt="grafik" src="https://github.com/user-attachments/assets/c63a8759-c86e-44cc-82c1-effa96f0299d" />
