### PR TITLE
chore: use recommended key length

### DIFF
--- a/deploy/ubuntu-server/edumfa-apache2.postinst
+++ b/deploy/ubuntu-server/edumfa-apache2.postinst
@@ -132,12 +132,12 @@ create_certificate() {
 adapt_edumfa_cfg() {
   if ! grep -q '^EDUMFA_PEPPER' /etc/edumfa/edumfa.cfg; then
     # PEPPER does not exist, yet
-    PEPPER="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c24)"
+    PEPPER="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c48)"
     echo "EDUMFA_PEPPER = '$PEPPER'" >> /etc/edumfa/edumfa.cfg
   fi
   if ! grep -q '^SECRET_KEY' /etc/edumfa/edumfa.cfg; then
     # SECRET_KEY does not exist, yet
-    SECRET="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c24)"
+    SECRET="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c48)"
     echo "SECRET_KEY = '$SECRET'" >> /etc/edumfa/edumfa.cfg
   fi
 }

--- a/deploy/ubuntu-server/edumfa-nginx.postinst
+++ b/deploy/ubuntu-server/edumfa-nginx.postinst
@@ -133,12 +133,12 @@ create_certificate() {
 adapt_edumfa_cfg() {
   if ! grep -q '^EDUMFA_PEPPER' /etc/edumfa/edumfa.cfg; then
     # PEPPER does not exist, yet
-    PEPPER="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c24)"
+    PEPPER="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c48)"
     echo "EDUMFA_PEPPER = '$PEPPER'" >> /etc/edumfa/edumfa.cfg
   fi
   if ! grep -q '^SECRET_KEY' /etc/edumfa/edumfa.cfg; then
     # SECRET_KEY does not exist, yet
-    SECRET="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c24)"
+    SECRET="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c48)"
     echo "SECRET_KEY = '$SECRET'" >> /etc/edumfa/edumfa.cfg
   fi
 }

--- a/doc/installation/docker.rst
+++ b/doc/installation/docker.rst
@@ -164,8 +164,8 @@ optional are required for eduMFA to work.
 - DB_HOSTNAME: the hostname of the database system
 - DB_PASSWORD: the password for DB_USER
 - DB_USER: the user on the database system
-- SECRET_KEY: the secret key which signs API tokens, should be at least 24 random characters long
-- EDUMFA_PEPPER: the pepper to use for password hashing, should be at least 24 random characters long
+- SECRET_KEY: the secret key which signs API tokens, should be at least 32 random characters long
+- EDUMFA_PEPPER: the pepper to use for password hashing, should be at least 32 random characters long
 - EDUMFA_ADMIN_PASS: the password for the local eduMFA admin (optional, default: will be generated)
 - EDUMFA_ADMIN_USER: the username for the local eduMFA admin (optional, default: ``admin``)
 - EDUMFA_AUDIT_KEY_PRIVATE: an alternative path to the audit key (optional, default: ``/etc/edumfa/private.pem``)

--- a/doc/installation/pip.rst
+++ b/doc/installation/pip.rst
@@ -76,9 +76,9 @@ Setting up eduMFA
 Additionally to the database connection a new ``EDUMFA_PEPPER`` and ``SECRET_KEY``
 must be generated in order to secure the installation::
 
-    PEPPER="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c24)"
+    PEPPER="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c48)"
     echo "EDUMFA_PEPPER = '$PEPPER'" >> /path/to/edumfa.cfg
-    SECRET="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c24)"
+    SECRET="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c48)"
     echo "SECRET_KEY = '$SECRET'" >> /path/to/edumfa.cfg
 
 An encryption key for encrypting the secrets in the database and a key for

--- a/edumfa/config.py
+++ b/edumfa/config.py
@@ -139,7 +139,7 @@ class ProductionConfig(Config):
     ) or "sqlite:///" + os.path.join(basedir, "data.sqlite")
     # SQLALCHEMY_DATABASE_URI = "mysql://pi2:pi2@localhost/pi2"
     # This is used to encrypt the auth_token
-    SECRET_KEY = os.environ.get("SECRET_KEY") or _random_password(24)
+    SECRET_KEY = os.environ.get("SECRET_KEY") or _random_password(48)
     # This is used to encrypt the admin passwords
     EDUMFA_PEPPER = "Never know..."
     # This is used to encrypt the token data and token passwords

--- a/tools/reset-edumfa
+++ b/tools/reset-edumfa
@@ -46,10 +46,10 @@ fi
 
 adapt_edumfa_cfg() {
 	    # PEPPER does not exist, yet
-	    PEPPER="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c24)"
+	    PEPPER="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c48)"
 	    echo "EDUMFA_PEPPER = '$PEPPER'" >> /etc/edumfa/edumfa.cfg
 	    # SECRET_KEY does not exist, yet
-	    SECRET="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c24)"
+	    SECRET="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c48)"
 	    echo "SECRET_KEY = '$SECRET'" >> /etc/edumfa/edumfa.cfg
 }
 


### PR DESCRIPTION
This avoids the InsecureKeyLengthWarning by pyjwt:  
`/opt/edumfa/lib/python3.12/site-packages/jwt/api_jwt.py:365: InsecureKeyLengthWarning: The HMAC key is 24 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
`