### PR TITLE
feat(image): add EDUMFA_ADMIN_ENABLE

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -52,6 +52,10 @@ create_keys() {
 }
 
 create_and_print_admin() {
+  EDUMFA_ADMIN_ENABLE="${EDUMFA_ADMIN_ENABLE:-true}"
+  if [ "${EDUMFA_ADMIN_ENABLE,,}" != "true" ]; then
+    return
+  fi
   if [ -n "$EDUMFA_ADMIN_USER_FILE" ]; then
     EDUMFA_ADMIN_USER=$(cat "$EDUMFA_ADMIN_USER_FILE")
   fi

--- a/doc/installation/docker.rst
+++ b/doc/installation/docker.rst
@@ -166,6 +166,7 @@ optional are required for eduMFA to work.
 - DB_USER: the user on the database system
 - SECRET_KEY: the secret key which signs API tokens, should be at least 32 random characters long
 - EDUMFA_PEPPER: the pepper to use for password hashing, should be at least 32 random characters long
+- EDUMFA_ADMIN_ENABLE: whether to enable creation of the local eduMFA admin (optional, default: ``true``)
 - EDUMFA_ADMIN_PASS: the password for the local eduMFA admin (optional, default: will be generated)
 - EDUMFA_ADMIN_USER: the username for the local eduMFA admin (optional, default: ``admin``)
 - EDUMFA_AUDIT_KEY_PRIVATE: an alternative path to the audit key (optional, default: ``/etc/edumfa/private.pem``)


### PR DESCRIPTION
Currently, a local eduMFA admin always gets created in the image. Some users want to disable that to reduce attack surface.  
It also makes the Helm chart configuration a little easier to grasp.