### PR TITLE
fix(image): add EDUMFA_ADMIN_ENABLE_FILE

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -52,6 +52,9 @@ create_keys() {
 }
 
 create_and_print_admin() {
+  if [ -n "$EDUMFA_ADMIN_ENABLE_FILE" ]; then
+    EDUMFA_ADMIN_ENABLE=$(cat "$EDUMFA_ADMIN_ENABLE_FILE")
+  fi
   EDUMFA_ADMIN_ENABLE="${EDUMFA_ADMIN_ENABLE:-true}"
   if [ "${EDUMFA_ADMIN_ENABLE,,}" != "true" ]; then
     return


### PR DESCRIPTION
Adds the _FILE counterpart for  #1262. It's a _little_ strange to support this.  
However, as the entrypoint script likely will turn to Python soon, this should be less strange with `get_env` from `edumfa_config.py`. Also with this we don't have to start making exceptions for "everything can be _FILEd".